### PR TITLE
[#19]: Font extension

### DIFF
--- a/ToTheMoon/ToTheMoon.xcodeproj/project.pbxproj
+++ b/ToTheMoon/ToTheMoon.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		9935C76F2D3FDD6000722D84 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 9935C76E2D3FDD6000722D84 /* RxCocoa */; };
 		9935C7712D3FDD6000722D84 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = 9935C7702D3FDD6000722D84 /* RxRelay */; };
 		9935C7732D3FDD6000722D84 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 9935C7722D3FDD6000722D84 /* RxSwift */; };
+		9968CF602D4616CF00C7391D /* Tabman in Frameworks */ = {isa = PBXBuildFile; productRef = 9968CF5F2D4616CF00C7391D /* Tabman */; };
+		9968CF632D4616FB00C7391D /* Pageboy in Frameworks */ = {isa = PBXBuildFile; productRef = 9968CF622D4616FB00C7391D /* Pageboy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -43,6 +45,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9968CF632D4616FB00C7391D /* Pageboy in Frameworks */,
+				9968CF602D4616CF00C7391D /* Tabman in Frameworks */,
 				9935C7712D3FDD6000722D84 /* RxRelay in Frameworks */,
 				9935C76F2D3FDD6000722D84 /* RxCocoa in Frameworks */,
 				9935C7732D3FDD6000722D84 /* RxSwift in Frameworks */,
@@ -93,6 +97,8 @@
 				9935C76E2D3FDD6000722D84 /* RxCocoa */,
 				9935C7702D3FDD6000722D84 /* RxRelay */,
 				9935C7722D3FDD6000722D84 /* RxSwift */,
+				9968CF5F2D4616CF00C7391D /* Tabman */,
+				9968CF622D4616FB00C7391D /* Pageboy */,
 			);
 			productName = ToTheMoon;
 			productReference = 9935C6D02D3FDC5E00722D84 /* ToTheMoon.app */;
@@ -125,6 +131,8 @@
 			packageReferences = (
 				9935C76A2D3FDD4500722D84 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				9935C76D2D3FDD6000722D84 /* XCRemoteSwiftPackageReference "RxSwift" */,
+				9968CF5E2D4616CF00C7391D /* XCRemoteSwiftPackageReference "Tabman" */,
+				9968CF612D4616FB00C7391D /* XCRemoteSwiftPackageReference "Pageboy" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 9935C6D12D3FDC5E00722D84 /* Products */;
@@ -372,6 +380,22 @@
 				minimumVersion = 6.8.0;
 			};
 		};
+		9968CF5E2D4616CF00C7391D /* XCRemoteSwiftPackageReference "Tabman" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/uias/Tabman.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.2.0;
+			};
+		};
+		9968CF612D4616FB00C7391D /* XCRemoteSwiftPackageReference "Pageboy" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/uias/Pageboy.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.2.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -394,6 +418,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 9935C76D2D3FDD6000722D84 /* XCRemoteSwiftPackageReference "RxSwift" */;
 			productName = RxSwift;
+		};
+		9968CF5F2D4616CF00C7391D /* Tabman */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9968CF5E2D4616CF00C7391D /* XCRemoteSwiftPackageReference "Tabman" */;
+			productName = Tabman;
+		};
+		9968CF622D4616FB00C7391D /* Pageboy */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9968CF612D4616FB00C7391D /* XCRemoteSwiftPackageReference "Pageboy" */;
+			productName = Pageboy;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ToTheMoon/ToTheMoon.xcodeproj/project.pbxproj
+++ b/ToTheMoon/ToTheMoon.xcodeproj/project.pbxproj
@@ -11,8 +11,6 @@
 		9935C76F2D3FDD6000722D84 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 9935C76E2D3FDD6000722D84 /* RxCocoa */; };
 		9935C7712D3FDD6000722D84 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = 9935C7702D3FDD6000722D84 /* RxRelay */; };
 		9935C7732D3FDD6000722D84 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 9935C7722D3FDD6000722D84 /* RxSwift */; };
-		9968CF602D4616CF00C7391D /* Tabman in Frameworks */ = {isa = PBXBuildFile; productRef = 9968CF5F2D4616CF00C7391D /* Tabman */; };
-		9968CF632D4616FB00C7391D /* Pageboy in Frameworks */ = {isa = PBXBuildFile; productRef = 9968CF622D4616FB00C7391D /* Pageboy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -45,8 +43,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9968CF632D4616FB00C7391D /* Pageboy in Frameworks */,
-				9968CF602D4616CF00C7391D /* Tabman in Frameworks */,
 				9935C7712D3FDD6000722D84 /* RxRelay in Frameworks */,
 				9935C76F2D3FDD6000722D84 /* RxCocoa in Frameworks */,
 				9935C7732D3FDD6000722D84 /* RxSwift in Frameworks */,
@@ -97,8 +93,6 @@
 				9935C76E2D3FDD6000722D84 /* RxCocoa */,
 				9935C7702D3FDD6000722D84 /* RxRelay */,
 				9935C7722D3FDD6000722D84 /* RxSwift */,
-				9968CF5F2D4616CF00C7391D /* Tabman */,
-				9968CF622D4616FB00C7391D /* Pageboy */,
 			);
 			productName = ToTheMoon;
 			productReference = 9935C6D02D3FDC5E00722D84 /* ToTheMoon.app */;
@@ -131,8 +125,6 @@
 			packageReferences = (
 				9935C76A2D3FDD4500722D84 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				9935C76D2D3FDD6000722D84 /* XCRemoteSwiftPackageReference "RxSwift" */,
-				9968CF5E2D4616CF00C7391D /* XCRemoteSwiftPackageReference "Tabman" */,
-				9968CF612D4616FB00C7391D /* XCRemoteSwiftPackageReference "Pageboy" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 9935C6D12D3FDC5E00722D84 /* Products */;
@@ -380,22 +372,6 @@
 				minimumVersion = 6.8.0;
 			};
 		};
-		9968CF5E2D4616CF00C7391D /* XCRemoteSwiftPackageReference "Tabman" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/uias/Tabman.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.2.0;
-			};
-		};
-		9968CF612D4616FB00C7391D /* XCRemoteSwiftPackageReference "Pageboy" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/uias/Pageboy.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.2.0;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -418,16 +394,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 9935C76D2D3FDD6000722D84 /* XCRemoteSwiftPackageReference "RxSwift" */;
 			productName = RxSwift;
-		};
-		9968CF5F2D4616CF00C7391D /* Tabman */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 9968CF5E2D4616CF00C7391D /* XCRemoteSwiftPackageReference "Tabman" */;
-			productName = Tabman;
-		};
-		9968CF622D4616FB00C7391D /* Pageboy */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 9968CF612D4616FB00C7391D /* XCRemoteSwiftPackageReference "Pageboy" */;
-			productName = Pageboy;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ToTheMoon/ToTheMoon.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ToTheMoon/ToTheMoon.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "e624acb41f62b01a1e2e412b0be2417f1ce3603ff38d35f7704a88cbf1823563",
+  "originHash" : "77d97d8ce1ad894d79ef4a4ea8c12776c8480dae971dc27122cfd8e0fd4b33fd",
   "pins" : [
-    {
-      "identity" : "pageboy",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/uias/Pageboy",
-      "state" : {
-        "revision" : "be0c1f6f1964cfb07f9d819b0863f2c3f255f612",
-        "version" : "4.2.0"
-      }
-    },
     {
       "identity" : "rxswift",
       "kind" : "remoteSourceControl",
@@ -26,15 +17,6 @@
       "state" : {
         "revision" : "2842e6e84e82eb9a8dac0100ca90d9444b0307f4",
         "version" : "5.7.1"
-      }
-    },
-    {
-      "identity" : "tabman",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/uias/Tabman.git",
-      "state" : {
-        "revision" : "3b2213290eb93e55bb50b49d1a179033005c11ab",
-        "version" : "3.2.0"
       }
     }
   ],

--- a/ToTheMoon/ToTheMoon.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ToTheMoon/ToTheMoon.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "3d2be6b35c949a6878dca02d89e5efa6d4c142ddf538f849fafb8845144fd6e3",
+  "originHash" : "e624acb41f62b01a1e2e412b0be2417f1ce3603ff38d35f7704a88cbf1823563",
   "pins" : [
+    {
+      "identity" : "pageboy",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/uias/Pageboy",
+      "state" : {
+        "revision" : "be0c1f6f1964cfb07f9d819b0863f2c3f255f612",
+        "version" : "4.2.0"
+      }
+    },
     {
       "identity" : "rxswift",
       "kind" : "remoteSourceControl",
@@ -17,6 +26,15 @@
       "state" : {
         "revision" : "2842e6e84e82eb9a8dac0100ca90d9444b0307f4",
         "version" : "5.7.1"
+      }
+    },
+    {
+      "identity" : "tabman",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/uias/Tabman.git",
+      "state" : {
+        "revision" : "3b2213290eb93e55bb50b49d1a179033005c11ab",
+        "version" : "3.2.0"
       }
     }
   ],

--- a/ToTheMoon/ToTheMoon/Extension/Font.swift
+++ b/ToTheMoon/ToTheMoon/Extension/Font.swift
@@ -1,0 +1,57 @@
+//
+//  Font.swift
+//  ToTheMoon
+//
+//  Created by 황석범 on 1/25/25.
+//
+
+import UIKit.UIFont
+
+extension UIFont {
+    enum FontType {
+        case extraLarge
+        case large
+        case medium
+        case small
+        case extraSmall
+        
+        /// 각 타입에 맞는 폰트 크기 반환 (4의 배수)
+        var size: CGFloat {
+            switch self {
+            case .extraLarge: return 32 // 4 * 8
+            case .large: return 24     // 4 * 6
+            case .medium: return 16    // 4 * 4
+            case .small: return 12     // 4 * 3
+            case .extraSmall: return 8 // 4 * 2
+            }
+        }
+        
+        /// 각 타입에 맞는 폰트 반환
+        var font: UIFont {
+            return UIFont.systemFont(ofSize: self.size) // 시스템 기본 폰트 사용
+        }
+    }
+}
+
+// UIFont의 커스텀 속성 추가
+extension UIFont {
+    static var extraLarge: UIFont {
+        return FontType.extraLarge.font
+    }
+    
+    static var large: UIFont {
+        return FontType.large.font
+    }
+    
+    static var medium: UIFont {
+        return FontType.medium.font
+    }
+    
+    static var small: UIFont {
+        return FontType.small.font
+    }
+    
+    static var extraSmall: UIFont {
+        return FontType.extraSmall.font
+    }
+}

--- a/ToTheMoon/ToTheMoon/Extension/Font.swift
+++ b/ToTheMoon/ToTheMoon/Extension/Font.swift
@@ -26,32 +26,38 @@ extension UIFont {
             }
         }
         
-        /// 각 타입에 맞는 폰트 반환
-        var font: UIFont {
-            return UIFont.systemFont(ofSize: self.size) // 시스템 기본 폰트 사용
+        /// 일반 폰트 반환
+        func regular() -> UIFont {
+            return UIFont.systemFont(ofSize: self.size)
+        }
+        
+        /// 굵은 폰트 반환
+        func bold() -> UIFont {
+            return UIFont.systemFont(ofSize: self.size, weight: .bold)
         }
     }
 }
 
 // UIFont의 커스텀 속성 추가
 extension UIFont {
-    static var extraLarge: UIFont {
-        return FontType.extraLarge.font
+    static var extraLarge: FontType {
+        return .extraLarge
     }
     
-    static var large: UIFont {
-        return FontType.large.font
+    static var large: FontType {
+        return .large
     }
     
-    static var medium: UIFont {
-        return FontType.medium.font
+    static var medium: FontType {
+        return .medium
     }
     
-    static var small: UIFont {
-        return FontType.small.font
+    static var small: FontType {
+        return .small
     }
     
-    static var extraSmall: UIFont {
-        return FontType.extraSmall.font
+    static var extraSmall: FontType {
+        return .extraSmall
     }
 }
+


### PR DESCRIPTION
### 📝 작업 내용
  - 뷰 작업할 때 공통 된 폰트 사이즈를 사용하도록 font extension 구현 

### 🚀 주요 변경 사항
- 4의 배수 단위로 5단계로 분리 
- 이름 짓기 힘들어서 Extra Large, Large .... 로 분리...

### 사용 예제
<img width="421" alt="image" src="https://github.com/user-attachments/assets/c2cc0eb4-7715-422c-8562-b24271a35846" />

<img width="162" alt="image" src="https://github.com/user-attachments/assets/29f798f0-0bb6-4f2e-9026-7ec0e1cefe81" />


### 💡 추가 계획
  - 폰트 스타일이나 크기 회의 필요
