### PR TITLE
[#34]: 각 거래소 Service 객체 기능 1개씩 추가 및 빗썸 서비스 fetMarketPrices 메서드 수정 

### DIFF
--- a/ToTheMoon/ToTheMoon/Model/Bithumb/BithumbTickersResponse.swift
+++ b/ToTheMoon/ToTheMoon/Model/Bithumb/BithumbTickersResponse.swift
@@ -1,0 +1,92 @@
+//
+//  Untitled.swift
+//  ToTheMoon
+//
+//  Created by 황석범 on 1/31/25.
+//
+
+import Foundation
+
+// MARK: - Bithumb API 응답 모델
+struct BithumbTickersResponse: Decodable {
+    let data: CoinDataWrapper
+    
+    struct CoinDataWrapper: Codable {
+        let date: String
+        let coins: [String: CoinData]
+        
+        enum CodingKeys: String, CodingKey {
+            case date
+        }
+        
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.date = try container.decode(String.self, forKey: .date)
+            
+            let dynamicContainer = try decoder.container(keyedBy: DynamicCodingKeys.self)
+            var tempCoins = [String: CoinData]()
+            
+            for key in dynamicContainer.allKeys {
+                if key.stringValue != "date" {
+                    let coinData = try dynamicContainer.decode(CoinData.self, forKey: key)
+                    tempCoins[key.stringValue] = coinData
+                }
+            }
+            self.coins = tempCoins
+        }
+    }
+}
+
+// MARK: - 코인 데이터 모델
+struct CoinData: Decodable {
+    let openingPrice: Double
+    let closingPrice: Double
+    let minPrice: Double
+    let maxPrice: Double
+    let unitsTraded: Double
+    let accTradeValue: Double
+    let prevClosingPrice: Double
+    let unitsTraded24H: Double
+    let accTradeValue24H: Double
+    let fluctate24H: Double
+    let fluctateRate24H: Double
+    
+    enum CodingKeys: String, CodingKey {
+        case openingPrice = "opening_price"
+        case closingPrice = "closing_price"
+        case minPrice = "min_price"
+        case maxPrice = "max_price"
+        case unitsTraded = "units_traded"
+        case accTradeValue = "acc_trade_value"
+        case prevClosingPrice = "prev_closing_price"
+        case unitsTraded24H = "units_traded_24H"
+        case accTradeValue24H = "acc_trade_value_24H"
+        case fluctate24H = "fluctate_24H"
+        case fluctateRate24H = "fluctate_rate_24H"
+    }
+    
+    // API에서 모든 값을 문자열(String)로 제공하므로 Double 변환을 시도
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.openingPrice = Double(try container.decode(String.self, forKey: .openingPrice)) ?? 0.0
+        self.closingPrice = Double(try container.decode(String.self, forKey: .closingPrice)) ?? 0.0
+        self.minPrice = Double(try container.decode(String.self, forKey: .minPrice)) ?? 0.0
+        self.maxPrice = Double(try container.decode(String.self, forKey: .maxPrice)) ?? 0.0
+        self.unitsTraded = Double(try container.decode(String.self, forKey: .unitsTraded)) ?? 0.0
+        self.accTradeValue = Double(try container.decode(String.self, forKey: .accTradeValue)) ?? 0.0
+        self.prevClosingPrice = Double(try container.decode(String.self, forKey: .prevClosingPrice)) ?? 0.0
+        self.unitsTraded24H = Double(try container.decode(String.self, forKey: .unitsTraded24H)) ?? 0.0
+        self.accTradeValue24H = Double(try container.decode(String.self, forKey: .accTradeValue24H)) ?? 0.0
+        self.fluctate24H = Double(try container.decode(String.self, forKey: .fluctate24H)) ?? 0.0
+        self.fluctateRate24H = Double(try container.decode(String.self, forKey: .fluctateRate24H)) ?? 0.0
+    }
+}
+
+// MARK: - 동적 코딩 키 처리
+struct DynamicCodingKeys: CodingKey {
+    var stringValue: String
+    init?(stringValue: String) { self.stringValue = stringValue }
+    var intValue: Int? { return nil }
+    init?(intValue: Int) { return nil }
+}

--- a/ToTheMoon/ToTheMoon/SceneDelegate.swift
+++ b/ToTheMoon/ToTheMoon/SceneDelegate.swift
@@ -11,11 +11,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = UINavigationController(rootViewController: SearchViewController(viewModel: <#SearchViewModel#>))
+        window.rootViewController = UINavigationController(rootViewController: CustomTabBarViewController())
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/ToTheMoon/ToTheMoon/Services/SymbolService.swift
+++ b/ToTheMoon/ToTheMoon/Services/SymbolService.swift
@@ -13,6 +13,14 @@ final class SymbolService {
     private let networkManager = NetworkManager.shared
     private let baseURL = APIEndpoint.coinGecko.baseURL
     
+    func fetchCoinDataAll(coinSymbol: String) -> Single<SymbolData> {
+           let endpoint = "\(baseURL)/\(coinSymbol)"
+           guard let url = URL(string: endpoint) else {
+               return Single.error(NetworkError.invalidUrl)
+           }
+           return networkManager.fetch(url: url)
+       }
+    
     // 코인 심볼 -> 코인 ID 매핑을 저장하는 캐시
     private var symbolToIDMap: [String: String] = [:]
     

--- a/ToTheMoon/ToTheMoon/Services/UpbitService.swift
+++ b/ToTheMoon/ToTheMoon/Services/UpbitService.swift
@@ -34,6 +34,29 @@ final class UpbitService {
             }
     }
     
+    func fetchMarketPrice(symbol: String) -> Single<[MarketPrice]> {
+        let symbol = symbol.uppercased()
+        let endpoint = "\(baseURL)/v1/ticker?markets=KRW-\(symbol)"
+        guard let url = URL(string: endpoint) else {
+            return Single.error(NetworkError.invalidUrl)
+        }
+        return NetworkManager.shared.fetch(url: url)
+            .map { (response: [UpbitTickerResponse]) -> [MarketPrice] in
+                return response.map { ticker in
+                    MarketPrice(
+                        symbol: ticker.market,
+                        price: ticker.tradePrice,
+                        exchange: self.exchange.rawValue,
+                        change: ticker.change,
+                        changeRate: ticker.changeRate * 100,
+                        quoteVolume: ticker.tradeVolume,
+                        highPrice: ticker.highPrice,
+                        lowPrice: ticker.lowPrice
+                    )
+                }
+            }
+    }
+    
     func fetchCandles(symbol: String, interval: CandleInterval, count: Int) -> Single<[Candle]> {
         let intervalPath = interval.upbitAndBithumbRawValue
         let baseURL = Exchange.upbit.baseURL


### PR DESCRIPTION
### 📝 작업 내용
  -  1) 4개 거래소 현재 시세 데이터 심볼 단위 개별 요청 메서드 추가
  - 2) 빗썸 현재 모든 시세 데이터 메서드 수정 한번에 모든 데이터 가져오게 구현 

### 🚀 주요 변경 사항
- 2)번 내용 -> 다른 3개 거래소와 같게 1초마다 요청해도 잘 받와질 것으로 예상 
### 📷 스크린샷

### 💡 추가 계획