### PR TITLE
[#50]: 검색 화면 테이블 뷰 헤더 탑 패딩 제거 

### DIFF
--- a/ToTheMoon/ToTheMoon/View/Search/FavoritesViewCell.swift
+++ b/ToTheMoon/ToTheMoon/View/Search/FavoritesViewCell.swift
@@ -128,7 +128,6 @@ class FavoritesViewCell: UITableViewCell {
         marketNameLabel.text = nil
         priceLabel.text = nil
         priceChangeLabel.text = nil
-        isSaved = false
         updateAddButton(isSaved: isSaved) 
     }
     
@@ -165,8 +164,6 @@ class FavoritesViewCell: UITableViewCell {
     
     @objc private func addButtonTapped() {
         guard let coin = currentCoin else { return }
-        isSaved.toggle()
-        updateAddButton(isSaved: isSaved)
         addButtonAction?(coin)
     }
 }

--- a/ToTheMoon/ToTheMoon/View/Search/SearchView.swift
+++ b/ToTheMoon/ToTheMoon/View/Search/SearchView.swift
@@ -60,6 +60,8 @@ final class SearchView: UIView {
             make.top.equalTo(safeAreaLayoutGuide.snp.top).offset(10)
             make.leading.trailing.equalToSuperview().inset(16)
         }
+        
+        tableView.sectionHeaderTopPadding = 0
 
         tableView.snp.makeConstraints { make in
             make.top.equalTo(searchBar.snp.bottom).offset(10)

--- a/ToTheMoon/ToTheMoon/View/Search/SearchViewController.swift
+++ b/ToTheMoon/ToTheMoon/View/Search/SearchViewController.swift
@@ -209,7 +209,7 @@ extension SearchViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return searchMode == .recent ? UITableView.automaticDimension : 60
+        return searchMode == .recent ? 70 : 60
     }
     
     // MARK: - 최근 검색 기록을 클릭하면 해당 검색어로 검색 수행


### PR DESCRIPTION
### 📝 작업 내용
- 검색 화면 테이블 뷰 헤더 탑 패딩 제거 

### 🚀 주요 변경 사항



### 📷 스크린샷
<img width="367" alt="image" src="https://github.com/user-attachments/assets/6e204fcd-28ae-448f-8836-b2ff660d70d9" />



