### PR TITLE
[#54]: 관심목록 페이지 펼쳐짐 원인 해결, 탭 바 언더라인 초기값 일단 하드코딩해서 설정

### DIFF
--- a/ToTheMoon/ToTheMoon/View/Favorites/FavoritesContainerViewController.swift
+++ b/ToTheMoon/ToTheMoon/View/Favorites/FavoritesContainerViewController.swift
@@ -49,7 +49,7 @@ final class FavoritesContainerViewController: UIViewController {
         
         let tabCount = CGFloat(tabs.count)
         let collectionViewWidth = UIScreen.main.bounds.width
-        let tabWidth = collectionViewWidth / tabCount
+        let tabWidth = (collectionViewWidth / tabCount) - 16
         
         layout.itemSize = CGSize(width: tabWidth, height: 40)
         layout.sectionInset = .zero
@@ -57,12 +57,11 @@ final class FavoritesContainerViewController: UIViewController {
         DispatchQueue.main.async {
             let selectedIndex = self.selectedSegment.value.rawValue
             let leadingOffset = tabWidth * CGFloat(selectedIndex)
-            print(leadingOffset)
             self.topFavoritesView.underlineView.snp.remakeConstraints { make in
                 make.bottom.equalTo(self.topFavoritesView.tabCollectionView)
                 make.height.equalTo(2)
                 make.trailing.equalToSuperview().offset(-16)
-                make.width.equalTo(185)
+                make.width.equalTo(leadingOffset)
             }
             self.topFavoritesView.layoutIfNeeded()
         }

--- a/ToTheMoon/ToTheMoon/View/Favorites/NoFavoritesView.swift
+++ b/ToTheMoon/ToTheMoon/View/Favorites/NoFavoritesView.swift
@@ -77,8 +77,7 @@ final class NoFavoritesView: UIView {
         // 제약 조건 설정
         verticalStackView.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(40)
-            make.centerX.equalToSuperview()
-            make.leading.trailing.equalToSuperview().inset(16) // 좌우 여백
+            make.horizontalEdges.equalToSuperview().inset(16) // 좌우 여백
         }
         
         imageView.snp.makeConstraints { make in

--- a/ToTheMoon/ToTheMoon/View/Favorites/TopFavoritesView.swift
+++ b/ToTheMoon/ToTheMoon/View/Favorites/TopFavoritesView.swift
@@ -30,10 +30,12 @@ final class TopFavoritesView: UIView {
         layout.scrollDirection = .horizontal
         layout.minimumLineSpacing = 0
         layout.minimumInteritemSpacing = 0
+        layout.sectionInset = .zero
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.backgroundColor = .clear
+        collectionView.contentInset = .zero
         collectionView.register(TabCell.self, forCellWithReuseIdentifier: "TabCell")
         return collectionView
     }()
@@ -91,7 +93,7 @@ final class TopFavoritesView: UIView {
         }
         
         contentView.snp.makeConstraints { make in
-            make.top.equalTo(underlineView.snp.bottom).offset(8)
+            make.top.equalTo(tabCollectionView.snp.bottom).offset(8)
             make.leading.trailing.bottom.equalToSuperview()
         }
     }


### PR DESCRIPTION
### 📝 작업 내용
- 관심목록 페이지 펼쳐짐 원인 해결, 탭 바 언더라인 초기값 일단 하드코딩해서 설정

### 🚀 주요 변경 사항



### 📷 스크린샷




