### PR TITLE
[#55] : 네비게이션 바 타이틀 설정 및 코인 심볼 대문자로 변환

### DIFF
--- a/ToTheMoon/ToTheMoon/View/Chart/ChartView.swift
+++ b/ToTheMoon/ToTheMoon/View/Chart/ChartView.swift
@@ -12,16 +12,6 @@ import DGCharts
 class ChartView: UIView {
     
     // MARK: - UI 컴포넌트
-    
-    // 상단 BTC/Upbit 라벨
-    let coinTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "BTC/Upbit"
-        label.font = UIFont.boldSystemFont(ofSize: 18)
-        label.textColor = .text
-        label.textAlignment = .center
-        return label
-    }()
 
     // 현재 가격 라벨
     let currentPriceLabel: UILabel = {
@@ -31,7 +21,7 @@ class ChartView: UIView {
         label.textAlignment = .left
         return label
     }()
-
+    
     // 새로운 시간 버튼 컨테이너 뷰 (1분, 일, 주, 월 버튼을 그룹화)
     private let timeSelectorView: UIStackView = {
         let stackView = UIStackView()
@@ -98,9 +88,9 @@ class ChartView: UIView {
         return stackView
     }()
 
-    let totalSupplyLabel = ChartView.createInfoLabel(title: "총 발행 수량", value: "99,986,676,553")
-    let marketCapLabel = ChartView.createInfoLabel(title: "시가 총액", value: "2,904조 4,294억")
-    let circulatingSupplyLabel = ChartView.createInfoLabel(title: "현재 유통량", value: "57,764,441,098")
+    let totalSupplyLabel = ChartView.createInfoLabel(title: "총 발행 수량", value: "준비중")
+    let marketCapLabel = ChartView.createInfoLabel(title: "시가 총액", value: "준비중")
+    let circulatingSupplyLabel = ChartView.createInfoLabel(title: "현재 유통량", value: "준비중")
     
     // 디지털 자산 소개 컨테이너
     private let digitalAssetContainerView: UIView = {
@@ -205,7 +195,6 @@ class ChartView: UIView {
     private func setupUI() {
         backgroundColor = .background
 
-        addSubview(coinTitleLabel)
         addSubview(currentPriceLabel)
         addSubview(timeSelectorView)
 
@@ -255,13 +244,9 @@ class ChartView: UIView {
     
     // MARK: - 레이아웃 설정
     private func setupConstraints() {
-        coinTitleLabel.snp.makeConstraints { make in
-            make.top.equalTo(safeAreaLayoutGuide).offset(10)
-            make.centerX.equalToSuperview()
-        }
 
         currentPriceLabel.snp.makeConstraints { make in
-            make.top.equalTo(coinTitleLabel.snp.bottom).offset(8)
+            make.top.equalTo(safeAreaLayoutGuide).offset(10)
             make.leading.equalToSuperview().offset(20)
         }
         

--- a/ToTheMoon/ToTheMoon/View/Chart/ChartViewController.swift
+++ b/ToTheMoon/ToTheMoon/View/Chart/ChartViewController.swift
@@ -43,6 +43,7 @@ class ChartViewController: UIViewController {
         
         if let firstCoin = try? viewModel.selectedCoins.value().first {
             viewModel.fetchCandles(for: firstCoin)
+            updateNavigationBarTitle(with: firstCoin)
         }
         
         updateSelectedTimeFrame(.day)
@@ -65,6 +66,10 @@ class ChartViewController: UIViewController {
     @objc private func backButtonTapped() {
         navigationController?.popViewController(animated: true)
     }
+    
+    private func updateNavigationBarTitle(with coin: MarketPrice) {
+        title = "\(coin.symbol.uppercased()) / \(coin.exchange)"
+    }
 
     private func setupViews() {
         view.backgroundColor = .clear
@@ -82,6 +87,7 @@ class ChartViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] firstCoin in
                 self?.updateUI(with: firstCoin)
+                self?.updateNavigationBarTitle(with: firstCoin)
             })
             .disposed(by: disposeBag)
 
@@ -181,8 +187,7 @@ class ChartViewController: UIViewController {
 
         // 제목 및 코인 페어 표시
         let coinTitleText = "\(coinSymbol) / \(coinExchange)"
-        chartView.coinTitleLabel.text = coinTitleText
-        chartView.coinNameLabel.text = "\(coinSymbol) (\(coinExchange))"
+        chartView.coinNameLabel.text = "\(coinSymbol.uppercased()) (\(coinExchange))"
 
         // 가격 정보 바인딩 (중복 방지)
         viewModel.currentPrices
@@ -252,7 +257,7 @@ class ChartViewController: UIViewController {
             if let firstKey = info.keys.first, let description = info[firstKey] {
                 self.chartView.digitalAssetDescriptionTextView.text = description
             } else {
-                self.chartView.digitalAssetDescriptionTextView.text = "설명 데이터를 불러올 수 없습니다."
+                self.chartView.digitalAssetDescriptionTextView.text = "설명 데이터 준비중"
             }
         }
     }

--- a/ToTheMoon/ToTheMoon/View/CoinPrice/CoinPriceViewController.swift
+++ b/ToTheMoon/ToTheMoon/View/CoinPrice/CoinPriceViewController.swift
@@ -134,7 +134,7 @@ class CoinPriceViewController: UIViewController {
         viewModel.error
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { error in
-                print("Error occurred: \(error.localizedDescription)")
+//                print("Error occurred: \(error.localizedDescription)")
             })
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
### 📝 작업 내용
  - 차트 화면의 상단 코인 정보를 네비게이션 바 타이틀로 이동
  - 코인 심볼을 대문자로 변환

### 🚀 주요 변경 사항
- coinTitleLabel을 제거하고 네비게이션 바의 title로 변경
- MarketPrice.symbol.uppercased()를 적용하여 모든 심볼을 대문자로 표시

### 📷 스크린샷
<img width="400" alt="" src="https://github.com/user-attachments/assets/3c8cc32c-e05d-47c1-ab57-79be3e9ef4a1" />