### PR TITLE
[#4]: 탭바 위치 조정 및 Assets NumbersColor 라이트 모드 색상 변경

### DIFF
--- a/ToTheMoon/ToTheMoon/Assets.xcassets/Color/NumbersGreenColor.colorset/Contents.json
+++ b/ToTheMoon/ToTheMoon/Assets.xcassets/Color/NumbersGreenColor.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "77",
-          "green" : "208",
-          "red" : "62"
+          "blue" : "37",
+          "green" : "162",
+          "red" : "23"
         }
       },
       "idiom" : "universal"

--- a/ToTheMoon/ToTheMoon/View/TabBar/CustomTabBarViewController.swift
+++ b/ToTheMoon/ToTheMoon/View/TabBar/CustomTabBarViewController.swift
@@ -26,9 +26,19 @@ class CustomTabBarViewController: UIViewController {
     }
 
     private func setupUI() {
+        let backgroundView = UIView()
+        backgroundView.backgroundColor = .background
+        view.addSubview(backgroundView)
+        backgroundView.snp.makeConstraints { make in
+            make.leading.trailing.bottom.equalToSuperview()
+            make.height.equalTo(120)
+        }
+
+        
         view.addSubview(customTabBar)
         customTabBar.snp.makeConstraints { make in
             make.leading.trailing.bottom.equalToSuperview()
+            make.bottom.equalToSuperview().offset(-20)
             make.height.equalTo(80)
         }
     }


### PR DESCRIPTION
### 📝 작업 내용
  - 탭바를 살짝 위로 올림
  - Assets NumbersColor 라이트 모드 색상 변경

### 📷 스크린샷
<img width="200" alt="" src="https://github.com/user-attachments/assets/ba8abcee-20c9-42cd-b49a-8b723d698465" />
