### PR TITLE
[#77] : 즐겨찾기 버튼 기능 구현 및 상세화면 리펙토링

### DIFF
--- a/ToTheMoon/ToTheMoon/UseCase/ChartUseCase.swift
+++ b/ToTheMoon/ToTheMoon/UseCase/ChartUseCase.swift
@@ -1,0 +1,119 @@
+//
+//  ChartUseCase.swift
+//  ToTheMoon
+//
+//  Created by 강민성 on 2/12/25.
+//
+
+import RxSwift
+import DGCharts
+import Foundation
+
+// 캔들 데이터를 가져오는 공통 프로토콜
+protocol CandleServiceType {
+    func fetchCandles(symbol: String, interval: CandleInterval, count: Int) -> Single<[Candle]>
+}
+
+// ChartUseCase는 선택된 코인에 대한 캔들 데이터를 가져와서 차트에 필요한 데이터를 생성합니다.
+// 또한, SymbolService를 이용하여 코인 설명 데이터를 가져옵니다.
+final class ChartUseCase {
+    
+    private let exchange: Exchange?
+    private let services: [Exchange: CandleServiceType]
+    private let symbolService: SymbolService
+    
+    init(exchange: Exchange?) {
+        self.exchange = exchange
+        // 서비스 클래스는 아래 extension에서 CandleServiceType 준수를 선언합니다.
+        self.services = [
+            .bithumb: BithumbService() as CandleServiceType,
+            .coinone: CoinOneService() as CandleServiceType,
+            .korbit:  KorbitService() as CandleServiceType,
+            .upbit:   UpbitService() as CandleServiceType
+        ]
+        self.symbolService = SymbolService()
+    }
+    
+    // 지정된 코인과 캔들 간격에 대해 차트 데이터를 생성합니다.
+    func fetchChartData(for coin: MarketPrice, interval: CandleInterval) -> Observable<(dates: [String],
+                                                                                           entries: [CandleChartDataEntry],
+                                                                                           highest: String,
+                                                                                           lowest: String,
+                                                                                           xAxisFormatter: AxisValueFormatter)> {
+        guard let exchange = exchange, let service = services[exchange] else {
+            let emptyFormatter = IndexAxisValueFormatter(values: [])
+            return Observable.just(([], [], "0", "0", emptyFormatter))
+        }
+        
+        return service.fetchCandles(symbol: coin.symbol, interval: interval, count: 50)
+            .asObservable()
+            .map { candles in
+                // 캔들 응답의 타임스탬프를 날짜 문자열로 변환
+                let timestamps = candles.map { TimeInterval($0.timestamp / 1000) }
+                let formatter = DateFormatter()
+                let dateFormat: String
+                switch interval {
+                case .minute:
+                    dateFormat = "HH:mm"
+                case .day:
+                    dateFormat = "M월 d일"
+                case .week:
+                    dateFormat = "M월 W주"
+                case .month:
+                    dateFormat = "YYYY년 M월"
+                }
+                formatter.dateFormat = dateFormat
+                let dates = timestamps
+                    .map { formatter.string(from: Date(timeIntervalSince1970: $0)) }
+                    .reversed()
+                let datesArray = Array(dates)
+                
+                let entries = candles.enumerated().map { index, candle in
+                    CandleChartDataEntry(x: Double(index),
+                                           shadowH: candle.high,
+                                           shadowL: candle.low,
+                                           open: candle.open,
+                                           close: candle.close)
+                }
+                
+                let highest = candles.max(by: { $0.high < $1.high })?.high ?? 0
+                let lowest  = candles.min(by: { $0.low < $1.low })?.low ?? 0
+                let xAxisFormatter = IndexAxisValueFormatter(values: datesArray)
+                
+                return (datesArray, entries, "\(highest)", "\(lowest)", xAxisFormatter)
+            }
+    }
+    
+    // 지정된 코인 심볼 목록에 대해 코인 설명 정보를 가져옵니다.
+    func fetchCoinDescriptions(for symbols: [String]) -> Single<[String: String]> {
+        return symbolService.fetchCoinIDMap()
+            .flatMap { _ -> Single<[String: String]> in
+                let coinInfoRequests = symbols.map { symbol in
+                    self.fetchCoinDescription(symbol: self.convertToCoinGeckoID(symbol),
+                                              originalSymbol: symbol)
+                        .map { (symbol.uppercased(), $0.description.ko) }
+                }
+                return Single.zip(coinInfoRequests)
+                    .map { Dictionary(uniqueKeysWithValues: $0) }
+            }
+    }
+    
+    // 심볼을 코인게코 ID로 변환 (캐시된 매핑 사용)
+    private func convertToCoinGeckoID(_ symbol: String) -> String {
+        return symbolService.symbolToIDMap[symbol.lowercased()] ?? symbol
+    }
+    
+    private func fetchCoinDescription(symbol: String, originalSymbol: String) -> Single<SymbolData> {
+        return symbolService.fetchCoinDataAll(coinSymbol: symbol)
+            .catch { _ in
+                self.symbolService.fetchCoinDataAll(coinSymbol: originalSymbol)
+            }
+    }
+}
+
+// MARK: - CandleServiceType Conformance
+
+extension BithumbService: CandleServiceType {}
+extension CoinOneService: CandleServiceType {}
+extension KorbitService: CandleServiceType {}
+extension UpbitService: CandleServiceType {}

--- a/ToTheMoon/ToTheMoon/View/Chart/ChartView.swift
+++ b/ToTheMoon/ToTheMoon/View/Chart/ChartView.swift
@@ -173,6 +173,14 @@ class ChartView: UIView {
         stackView.alignment = .fill
         return stackView
     }()
+    
+    let favoriteButton: UIButton = {
+        let button = UIButton(type: .system)
+        let starImage = UIImage(systemName: "star") // 기본 아이콘 (비어있는 별)
+        button.setImage(starImage, for: .normal)
+        button.tintColor = .gray
+        return button
+    }()
 
     let highestPriceLabel = ChartView.createPriceLabel(text: "최고가")
     let highestPriceValueLabel = ChartView.createPriceValueLabel(textColor: .green)
@@ -197,6 +205,7 @@ class ChartView: UIView {
 
         addSubview(currentPriceLabel)
         addSubview(timeSelectorView)
+        addSubview(favoriteButton)
 
         // ✅ 스크롤뷰 추가
         addSubview(scrollView)
@@ -288,6 +297,12 @@ class ChartView: UIView {
 
         coinInfoStackView.snp.makeConstraints { make in
             make.top.leading.trailing.equalToSuperview().inset(10)
+        }
+        
+        favoriteButton.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().inset(20) // 우측 정렬
+            make.centerY.equalTo(currentPriceLabel) // 현재가 레이블과 정렬
+            make.width.height.equalTo(24) // 아이콘 크기
         }
 
         supplyInfoStackView.snp.makeConstraints { make in

--- a/ToTheMoon/ToTheMoon/View/Chart/ChartViewController.swift
+++ b/ToTheMoon/ToTheMoon/View/Chart/ChartViewController.swift
@@ -10,52 +10,50 @@ import UIKit
 import RxSwift
 import RxCocoa
 import DGCharts
+import SnapKit
 
 class ChartViewController: UIViewController {
-
+    
     private let chartView = ChartView()
     private let viewModel: ChartViewModel
     private let disposeBag = DisposeBag()
     private var uiDisposeBag = DisposeBag()
     private let coinPriceViewModel: CoinPriceViewModel
-
-    // 현재 선택된 시간 간격을 저장하는 변수
+    
+    // 현재 선택된 시간 간격 (초기값 .day)
     private var selectedTimeFrame: CandleInterval = .day
-
+    
     init(viewModel: ChartViewModel, coinPriceViewModel: CoinPriceViewModel) {
         print("DEBUG: Initializing ChartViewController with viewModel: \(viewModel)")
         self.viewModel = viewModel
         self.coinPriceViewModel = coinPriceViewModel
         super.init(nibName: nil, bundle: nil)
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+        
     override func viewDidLoad() {
         super.viewDidLoad()
         setupViews()
         setupBindings()
         bindViewModel()
+        bindSymbolImage()
         setupNavigationBar()
         navigationController?.navigationBar.isHidden = false
         
-        if let firstCoin = try? viewModel.selectedCoins.value().first {
-            viewModel.fetchCandles(for: firstCoin)
-            updateNavigationBarTitle(with: firstCoin)
-        }
-        
+        // 기본 시간 간격 설정 (.day)
         updateSelectedTimeFrame(.day)
     }
-
-    // 네비게이션 바 및 뒤로가기 버튼 설정
+    
+    // MARK: - Navigation Bar 설정
     private func setupNavigationBar() {
         navigationController?.navigationBar.prefersLargeTitles = false
-        navigationController?.navigationBar.tintColor = .black // 뒤로가기 버튼 색상
-
+        navigationController?.navigationBar.tintColor = .text
+        
         let backButton = UIBarButtonItem(
-            image: UIImage(systemName: "chevron.left"), // 뒤로가기 아이콘
+            image: UIImage(systemName: "chevron.left"),
             style: .plain,
             target: self,
             action: #selector(backButtonTapped)
@@ -70,7 +68,8 @@ class ChartViewController: UIViewController {
     private func updateNavigationBarTitle(with coin: MarketPrice) {
         title = "\(coin.symbol.uppercased()) / \(coin.exchange)"
     }
-
+    
+    // MARK: - View 설정
     private func setupViews() {
         view.backgroundColor = .clear
         view.addSubview(chartView)
@@ -78,46 +77,113 @@ class ChartViewController: UIViewController {
             make.edges.equalToSuperview()
         }
     }
-
+    
+    private func bindSymbolImage() {
+        viewModel.input.selectedCoins
+            .asObservable()
+            .map { $0.first?.symbol }      // 첫 번째 코인의 심볼만 가져옴
+            .distinctUntilChanged()          // 심볼이 바뀔 때만 업데이트
+            .subscribe(onNext: { [weak self] symbol in
+                guard let self = self, let symbol = symbol else { return }
+                // ImageRepository에서 해당 심볼에 맞는 이미지를 가져오고,
+                // 없으면 "default_coin" 이미지를 사용합니다.
+                let image = ImageRepository.getImage(for: symbol) ?? UIImage(named: "default_coin")
+                self.chartView.coinSymbolImageView.image = image
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    // MARK: - Binding 설정 (입력, 즐겨찾기 등)
     private func setupBindings() {
-        // 현재 선택된 첫 번째 코인 가져오기
-        viewModel.selectedCoins
-            .map { $0.first } // ✅ 첫 번째 코인만 가져옴
-            .compactMap { $0 } // ✅ nil 방지
+        chartView.favoriteButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                guard let self = self,
+                      let firstCoin = self.viewModel.input.selectedCoins.value.first else { return }
+                self.viewModel.toggleFavorite(for: firstCoin)
+            })
+            .disposed(by: disposeBag)
+        
+        viewModel.input.selectedCoins
+            .map { $0.first }
+            .compactMap { $0 }
+            .flatMap { [weak self] coin in
+                self?.viewModel.isFavorite(coin) ?? Observable.just(false)
+            }
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] isFavorite in
+                self?.updateFavoriteButtonUI(isFavorite: isFavorite)
+            })
+            .disposed(by: disposeBag)
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(updateFavoriteButtonState),
+            name: NSNotification.Name("FavoriteListUpdated"),
+            object: nil
+        )
+    }
+    
+    @objc private func updateFavoriteButtonState() {
+        guard let firstCoin = viewModel.input.selectedCoins.value.first else { return }
+        viewModel.isFavorite(firstCoin)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] isFavorite in
+                self?.updateFavoriteButtonUI(isFavorite: isFavorite)
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    private func updateFavoriteButtonUI(isFavorite: Bool) {
+        let imageName = isFavorite ? "star.fill" : "star"
+        chartView.favoriteButton.setImage(UIImage(systemName: imageName), for: .normal)
+        chartView.favoriteButton.tintColor = isFavorite ? .yellow : .gray
+        
+        viewModel.input.selectedCoins
+            .map { $0.first }
+            .compactMap { $0 }
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] firstCoin in
                 self?.updateUI(with: firstCoin)
                 self?.updateNavigationBarTitle(with: firstCoin)
             })
             .disposed(by: disposeBag)
-
-        // 차트 데이터 바인딩
-        viewModel.chartData
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] dates, entries in
-                self?.chartView.configureChart(dates: dates, dataEntries: entries)
+        
+        viewModel.output.chartData
+            .drive(onNext: { [weak self] chartData in
+                self?.chartView.configureChart(dates: chartData.dates, dataEntries: chartData.entries)
             })
             .disposed(by: disposeBag)
-
-        viewModel.chartXAxisFormatter
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] formatter in
-                self?.chartView.setXAxisFormatter(formatter)
+        
+        viewModel.output.highestPrice
+            .drive(onNext: { [weak self] highest in
+                self?.chartView.highestPriceValueLabel.text = highest
             })
             .disposed(by: disposeBag)
-
-        // 시간 버튼 바인딩 (RxSwift 활용)
+        
+        viewModel.output.lowestPrice
+            .drive(onNext: { [weak self] lowest in
+                self?.chartView.lowestPriceValueLabel.text = lowest
+            })
+            .disposed(by: disposeBag)
+        
+        viewModel.output.image
+            .drive(onNext: { [weak self] (symbol, image) in
+                guard let self = self,
+                      let firstCoin = self.viewModel.input.selectedCoins.value.first,
+                      firstCoin.symbol == symbol else { return }
+                self.chartView.coinSymbolImageView.image = image
+            })
+            .disposed(by: disposeBag)
+        
         setupTimeFrameBindings()
-
-        // 구글 검색 버튼 기능 추가
         chartView.googleSearchButton.rx.tap
             .subscribe(onNext: { [weak self] in
                 self?.searchCoinOnGoogle()
             })
             .disposed(by: disposeBag)
     }
-
-    // 시간 간격 버튼 Rx 바인딩 (분, 일, 주, 월만)
+    
+    // MARK: - 시간 간격 버튼 바인딩
     private func setupTimeFrameBindings() {
         let timeButtons: [(UIButton, CandleInterval)] = [
             (chartView.minuteButton, .minute),
@@ -125,7 +191,7 @@ class ChartViewController: UIViewController {
             (chartView.weekButton, .week),
             (chartView.monthButton, .month)
         ]
-
+        
         for (button, interval) in timeButtons {
             button.rx.tap
                 .subscribe(onNext: { [weak self] in
@@ -134,124 +200,83 @@ class ChartViewController: UIViewController {
                 .disposed(by: disposeBag)
         }
     }
-
-    // 선택된 시간 프레임 업데이트 (버튼 강조)
+    
     private func updateSelectedTimeFrame(_ newInterval: CandleInterval) {
         selectedTimeFrame = newInterval
-        viewModel.candleInterval.onNext(newInterval)
-
-        // 버튼 UI 업데이트
+        viewModel.input.candleInterval.accept(newInterval)
+        
         let allButtons = [chartView.minuteButton, chartView.dayButton, chartView.weekButton, chartView.monthButton]
         for button in allButtons {
             button.backgroundColor = .container
             button.setTitleColor(.text, for: .normal)
         }
-
+        
         switch newInterval {
-        case .minute: chartView.minuteButton.backgroundColor = .blue.withAlphaComponent(0.3)
-        case .day: chartView.dayButton.backgroundColor = .blue.withAlphaComponent(0.3)
-        case .week: chartView.weekButton.backgroundColor = .blue.withAlphaComponent(0.3)
-        case .month: chartView.monthButton.backgroundColor = .blue.withAlphaComponent(0.3)
-        default: break
+        case .minute:
+            chartView.minuteButton.backgroundColor = .blue.withAlphaComponent(0.3)
+        case .day:
+            chartView.dayButton.backgroundColor = .blue.withAlphaComponent(0.3)
+        case .week:
+            chartView.weekButton.backgroundColor = .blue.withAlphaComponent(0.3)
+        case .month:
+            chartView.monthButton.backgroundColor = .blue.withAlphaComponent(0.3)
         }
     }
-
-    // 구글 검색 버튼 기능 (해당 코인을 검색)
+    
     private func searchCoinOnGoogle() {
-        guard let firstCoin = try? viewModel.selectedCoins.value().first else { return }
+        guard let firstCoin = viewModel.input.selectedCoins.value.first else { return }
         let coinName = firstCoin.symbol.uppercased()
         let searchQuery = "https://www.google.com/search?q=\(coinName)+코인"
-        
         if let url = URL(string: searchQuery) {
             UIApplication.shared.open(url)
         }
     }
-
-    // ViewModel과 UI 바인딩
+    
     private func bindViewModel() {
-        viewModel.coinInfo
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] info in
+        viewModel.output.coinInfo
+            .drive(onNext: { [weak self] info in
                 self?.updateCoinDescription(info)
             })
             .disposed(by: disposeBag)
     }
-
-    // UI 업데이트 함수
+    
     private func updateUI(with firstCoin: MarketPrice) {
-        // 기존 UI 바인딩 해제 후 새로운 DisposeBag 생성
         uiDisposeBag = DisposeBag()
         
         let coinSymbol = firstCoin.symbol
         let coinExchange = firstCoin.exchange
-
-        // 제목 및 코인 페어 표시
-        let coinTitleText = "\(coinSymbol) / \(coinExchange)"
         chartView.coinNameLabel.text = "\(coinSymbol.uppercased()) (\(coinExchange))"
-
-        // 가격 정보 바인딩 (중복 방지)
-        viewModel.currentPrices
+        
+        viewModel.output.currentPrices
             .map { $0[firstCoin.symbol] ?? "0" }
             .distinctUntilChanged()
-            .bind(to: chartView.currentPriceLabel.rx.text)
+            .drive(chartView.currentPriceLabel.rx.text)
             .disposed(by: uiDisposeBag)
-
-        viewModel.priceChangeRates
+        
+        viewModel.output.priceChangeRates
             .map { rates in
                 let formattedRates = rates.mapValues { value in
                     if let doubleValue = Double(value.replacingOccurrences(of: "%", with: "")) {
-                        return String(format: "%.2f%%", doubleValue) // ✅ 소수점 2자리까지 변환
+                        return String(format: "%.2f%%", doubleValue)
                     }
                     return value
                 }
                 return formattedRates
             }
-            .map { $0[firstCoin.symbol] ?? "0%" } // ✅ 특정 코인의 변동률만 가져옴
+            .map { $0[firstCoin.symbol] ?? "0%" }
             .distinctUntilChanged()
-            .bind(to: chartView.changeRateValueLabel.rx.text)
-            .disposed(by: uiDisposeBag)
-
-        // 최고가 / 최저가 업데이트
-        viewModel.highestPrice
-            .distinctUntilChanged()
-            .bind(to: chartView.highestPriceValueLabel.rx.text)
-            .disposed(by: uiDisposeBag)
-
-        viewModel.lowestPrice
-            .distinctUntilChanged()
-            .bind(to: chartView.lowestPriceValueLabel.rx.text)
+            .drive(chartView.changeRateValueLabel.rx.text)
             .disposed(by: uiDisposeBag)
         
-        // 심볼 이미지 적용 (기본 이미지 → 네트워크 이미지)
-        let defaultImage = UIImage(named: "default_coin")
-
-        if let cachedImage = ImageRepository.getImage(for: coinSymbol) {
-            chartView.coinSymbolImageView.image = cachedImage
-        } else {
-            chartView.coinSymbolImageView.image = defaultImage
-
-            viewModel.imageSubject
-                .filter { $0.0 == coinSymbol }
-                .map { $0.1 }
-                .observe(on: MainScheduler.instance)
-                .subscribe(onNext: { [weak self] image in
-                    self?.chartView.coinSymbolImageView.image = image ?? defaultImage
-                })
-                .disposed(by: uiDisposeBag)
-        }
-
-        // 디지털 자산 소개 업데이트
-        viewModel.coinInfo
+        viewModel.output.coinInfo
             .map { $0[firstCoin.symbol.uppercased()] ?? "설명 데이터를 가져올 수 없습니다." }
             .distinctUntilChanged()
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] description in
+            .drive(onNext: { [weak self] description in
                 self?.chartView.digitalAssetDescriptionTextView.text = description
             })
             .disposed(by: uiDisposeBag)
     }
-
-    // 코인 설명 UI 업데이트 함수
+    
     private func updateCoinDescription(_ info: [String: String]) {
         DispatchQueue.main.async {
             if let firstKey = info.keys.first, let description = info[firstKey] {

--- a/ToTheMoon/ToTheMoon/ViewModel/ChartViewModel.swift
+++ b/ToTheMoon/ToTheMoon/ViewModel/ChartViewModel.swift
@@ -8,175 +8,147 @@
 
 import RxSwift
 import RxCocoa
-import UIKit
 import DGCharts
+import Foundation
+import UIKit
 
 final class ChartViewModel {
-
-    // MARK: - Inputs
-    let exchange: Exchange?
-    let selectedCoins: BehaviorSubject<[MarketPrice]>
-    let candleInterval = BehaviorSubject<CandleInterval>(value: .day)
-
-    // MARK: - Outputs
-    let chartData = PublishSubject<([String], [CandleChartDataEntry])>()
-    let highestPrice = BehaviorSubject<String>(value: "0")
-    let lowestPrice = BehaviorSubject<String>(value: "0")
-    let currentPrices = BehaviorSubject<[String: String]>(value: [:])
-    let priceChangeRates = BehaviorSubject<[String: String]>(value: [:])
-    let coinInfo = BehaviorSubject<[String: String]>(value: [:])
-    let imageSubject = PublishSubject<(String, UIImage?)>()
-    let chartXAxisFormatter = PublishSubject<AxisValueFormatter>()
-
-    // MARK: - Dependencies
+    
+    // MARK: - Input & Output 구조체
+    struct Input {
+        let selectedCoins: BehaviorRelay<[MarketPrice]>
+        let candleInterval: BehaviorRelay<CandleInterval>
+    }
+    
+    struct Output {
+        let chartData: Driver<(dates: [String], entries: [CandleChartDataEntry], highest: String, lowest: String, xAxisFormatter: AxisValueFormatter)>
+        let currentPrices: Driver<[String: String]>
+        let priceChangeRates: Driver<[String: String]>
+        let coinInfo: Driver<[String: String]>
+        let highestPrice: Driver<String>
+        let lowestPrice: Driver<String>
+        let image: Driver<(String, UIImage?)>
+    }
+    
+    let input: Input
+    let output: Output
+    
+    // MARK: - Private Properties
     private let disposeBag = DisposeBag()
-    private let symbolService = SymbolService()
-    private let services: [Exchange: Any]
-
-    // MARK: - Initializer
+    private let chartUseCase: ChartUseCase
+    
+    // 내부 Relay
+    private let chartDataRelay = PublishRelay<(dates: [String], entries: [CandleChartDataEntry], highest: String, lowest: String, xAxisFormatter: AxisValueFormatter)>()
+    private let currentPricesRelay = BehaviorRelay<[String: String]>(value: [:])
+    private let priceChangeRatesRelay = BehaviorRelay<[String: String]>(value: [:])
+    private let coinInfoRelay = BehaviorRelay<[String: String]>(value: [:])
+    private let highestPriceRelay = BehaviorRelay<String>(value: "0")
+    private let lowestPriceRelay = BehaviorRelay<String>(value: "0")
+    private let imageSubject = PublishSubject<(String, UIImage?)>()
+    
     init(exchange: Exchange?, selectedCoins: [MarketPrice]) {
-        self.exchange = exchange
-        self.selectedCoins = BehaviorSubject(value: selectedCoins)
-
-        self.services = [
-            .bithumb: BithumbService(),
-            .coinone: CoinOneService(),
-            .korbit: KorbitService(),
-            .upbit: UpbitService()
-        ]
-
+        let selectedCoinsRelay = BehaviorRelay<[MarketPrice]>(value: selectedCoins)
+        let candleIntervalRelay = BehaviorRelay<CandleInterval>(value: .day)
+        self.input = Input(selectedCoins: selectedCoinsRelay, candleInterval: candleIntervalRelay)
+        
+        self.chartUseCase = ChartUseCase(exchange: exchange)
+        
+        self.output = Output(
+            chartData: chartDataRelay.asDriver(onErrorDriveWith: .empty()),
+            currentPrices: currentPricesRelay.asDriver(),
+            priceChangeRates: priceChangeRatesRelay.asDriver(),
+            coinInfo: coinInfoRelay.asDriver(),
+            highestPrice: highestPriceRelay.asDriver(),
+            lowestPrice: lowestPriceRelay.asDriver(),
+            image: imageSubject.asDriver(onErrorDriveWith: .empty())
+        )
+        
         setupBindings()
     }
-
-    // MARK: - Setup Bindings
+    
     private func setupBindings() {
-        bindSelectedCoins()
-        bindCandleInterval()
-    }
-
-    private func bindSelectedCoins() {
-        selectedCoins
+        input.selectedCoins.asObservable()
             .subscribe(onNext: { [weak self] coins in
                 guard let self = self, let firstCoin = coins.first else { return }
-                self.updatePriceInfo(coins)
-                self.fetchAllCoinInfo(symbols: coins.map { $0.symbol })
-                self.fetchCandles(for: firstCoin)
-            })
-            .disposed(by: disposeBag)
-    }
-
-    private func bindCandleInterval() {
-        candleInterval
-            .distinctUntilChanged()
-            .subscribe(onNext: { [weak self] _ in
-                guard let self = self, let firstCoin = try? self.selectedCoins.value().first else { return }
-                self.fetchCandles(for: firstCoin)
-            })
-            .disposed(by: disposeBag)
-    }
-
-    // MARK: - 가격 및 변동률 업데이트
-    private func updatePriceInfo(_ coins: [MarketPrice]) {
-        let currentPricesDict = Dictionary(uniqueKeysWithValues: coins.map { ($0.symbol, "KRW \($0.price)") })
-        let priceChangeRatesDict = Dictionary(uniqueKeysWithValues: coins.map { ($0.symbol, "\($0.changeRate)%") })
-        
-        currentPrices.onNext(currentPricesDict)
-        priceChangeRates.onNext(priceChangeRatesDict)
-    }
-
-    // MARK: - 모든 코인의 설명 가져오기
-    private func fetchAllCoinInfo(symbols: [String]) {
-        symbolService.fetchCoinIDMap()
-            .flatMap { [weak self] _ -> Single<[String: String]> in
-                guard let self = self else { return .just([:]) }
+                let currentPricesDict = Dictionary(uniqueKeysWithValues: coins.map { ($0.symbol, "KRW \($0.price)") })
+                let changeRatesDict = Dictionary(uniqueKeysWithValues: coins.map { ($0.symbol, "\($0.changeRate)%") })
+                self.currentPricesRelay.accept(currentPricesDict)
+                self.priceChangeRatesRelay.accept(changeRatesDict)
                 
-                let coinInfoRequests = symbols.map { symbol in
-                    self.fetchCoinDescription(symbol: self.convertToCoinGeckoID(symbol), originalSymbol: symbol)
-                        .map { ($0.symbol.uppercased(), $0.description.ko) }
+                let symbols = coins.map { $0.symbol }
+                self.chartUseCase.fetchCoinDescriptions(for: symbols)
+                    .subscribe(onSuccess: { descriptions in
+                        self.coinInfoRelay.accept(descriptions)
+                    })
+                    .disposed(by: self.disposeBag)
+                
+                let interval = self.input.candleInterval.value
+                self.chartUseCase.fetchChartData(for: firstCoin, interval: interval)
+                    .subscribe(onNext: { data in
+                        self.chartDataRelay.accept(data)
+                        self.highestPriceRelay.accept(data.highest)
+                        self.lowestPriceRelay.accept(data.lowest)
+                    })
+                    .disposed(by: self.disposeBag)
+                
+                if let image = ImageRepository.getImage(for: firstCoin.symbol) {
+                    self.imageSubject.onNext((firstCoin.symbol, image))
+                } else {
+                    let defaultImage = UIImage(named: "default_coin")
+                    self.imageSubject.onNext((firstCoin.symbol, defaultImage))
                 }
-                
-                return Single.zip(coinInfoRequests)
-                    .map { Dictionary(uniqueKeysWithValues: $0) }
-            }
-            .observe(on: MainScheduler.instance)
-            .subscribe(onSuccess: { [weak self] coinDescriptions in
-                self?.coinInfo.onNext(coinDescriptions)
+            })
+            .disposed(by: disposeBag)
+        
+        input.candleInterval.asObservable()
+            .distinctUntilChanged()
+            .withLatestFrom(input.selectedCoins.asObservable()) { (interval: $0, coins: $1) }
+            .subscribe(onNext: { [weak self] tuple in
+                guard let self = self, let firstCoin = tuple.coins.first else { return }
+                self.chartUseCase.fetchChartData(for: firstCoin, interval: tuple.interval)
+                    .subscribe(onNext: { data in
+                        self.chartDataRelay.accept(data)
+                        self.highestPriceRelay.accept(data.highest)
+                        self.lowestPriceRelay.accept(data.lowest)
+                    })
+                    .disposed(by: self.disposeBag)
             })
             .disposed(by: disposeBag)
     }
-
-    private func convertToCoinGeckoID(_ symbol: String) -> String {
-        return symbolService.symbolToIDMap[symbol.lowercased()] ?? symbol
-    }
-
-    private func fetchCoinDescription(symbol: String, originalSymbol: String) -> Single<SymbolData> {
-        return symbolService.fetchCoinDataAll(coinSymbol: symbol)
-            .catch { [weak self] _ in
-                guard let self = self else { return .never() }
-                return self.symbolService.fetchCoinDataAll(coinSymbol: originalSymbol)
-            }
-    }
-
-    // MARK: - 캔들 데이터 가져오기
-    func fetchCandles(for coin: MarketPrice) {
-        guard let exchange = self.exchange, let service = services[exchange] else {
-            self.chartData.onNext(([], []))
-            return
-        }
-
-        guard let interval = try? self.candleInterval.value() else { return }
-        let fetchObservable: Observable<[Candle]>
-
-        switch service {
-        case let service as BithumbService:
-            fetchObservable = service.fetchCandles(symbol: coin.symbol, interval: interval, count: 50).asObservable()
-        case let service as UpbitService:
-            fetchObservable = service.fetchCandles(symbol: coin.symbol, interval: interval, count: 50).asObservable()
-        case let service as CoinOneService:
-            fetchObservable = service.fetchCandles(symbol: coin.symbol, interval: interval, count: 50).asObservable()
-        case let service as KorbitService:
-            fetchObservable = service.fetchCandles(symbol: coin.symbol, interval: interval, count: 50).asObservable()
-        default:
-            self.chartData.onNext(([], []))
-            return
-        }
-
-        fetchObservable
-            .subscribe(onNext: { [weak self] candles in
-                self?.updateChartData(candles, interval: interval)
+    
+    // 즐겨찾기 관련 기능 (Core Data 연동)
+    func toggleFavorite(for coin: MarketPrice) {
+        // 우선 현재 즐겨찾기 상태를 확인하여 추가 혹은 삭제를 수행
+        isFavorite(coin)
+            .take(1)
+            .subscribe(onNext: { [weak self] isFav in
+                guard let self = self else { return }
+                if isFav {
+                    // 즐겨찾기에서 삭제
+                    CoreDataManager.shared.deleteCoin(symbol: coin.symbol, exchange: coin.exchange)
+                        .subscribe(onCompleted: {
+                            print("Removed \(coin.symbol) from favorites")
+                            NotificationCenter.default.post(name: NSNotification.Name("FavoriteListUpdated"), object: nil)
+                        })
+                        .disposed(by: self.disposeBag)
+                } else {
+                    // 즐겨찾기에 추가
+                    CoreDataManager.shared.createCoin(name: coin.symbol, symbol: coin.symbol, exchange: coin.exchange)
+                        .subscribe(onCompleted: {
+                            print("Added \(coin.symbol) to favorites")
+                            NotificationCenter.default.post(name: NSNotification.Name("FavoriteListUpdated"), object: nil)
+                        })
+                        .disposed(by: self.disposeBag)
+                }
             })
             .disposed(by: disposeBag)
     }
-
-    // MARK: - 차트 데이터 업데이트
-    private func updateChartData(_ candles: [Candle], interval: CandleInterval) {
-        let timestamps = candles.map { TimeInterval($0.timestamp / 1000) }
-
-        let formatter = DateFormatter()
-        formatter.dateFormat = {
-            switch interval {
-            case .minute: return "HH:mm"
-            case .day: return "M월 d일"
-            case .week: return "M월 W주"
-            case .month: return "YYYY년 M월"
+    
+    func isFavorite(_ coin: MarketPrice) -> Observable<Bool> {
+        return CoreDataManager.shared.fetchCoins()
+            .map { coins in
+                coins.contains { $0.symbol == coin.symbol && $0.exchangename == coin.exchange }
             }
-        }()
-
-        let dates = timestamps
-            .map { formatter.string(from: Date(timeIntervalSince1970: $0)) }
-            .reversed()
-
-        let entries = candles.enumerated().map { index, candle in
-            CandleChartDataEntry(x: Double(index), shadowH: candle.high, shadowL: candle.low, open: candle.open, close: candle.close)
-        }
-
-        chartData.onNext((Array(dates), entries))
-        chartXAxisFormatter.onNext(IndexAxisValueFormatter(values: Array(dates)))
-
-        if let highest = candles.max(by: { $0.high < $1.high })?.high,
-           let lowest = candles.min(by: { $0.low < $1.low })?.low {
-            highestPrice.onNext("\(highest)")
-            lowestPrice.onNext("\(lowest)")
-        }
+            .distinctUntilChanged()
     }
 }


### PR DESCRIPTION
### 📝 작업 내용
  - ChartUseCase 리팩토링 및 유즈케이스 분리
  - 즐겨찾기 기능을 위한 FavoriteManager 추가
  - ViewModel에서 UseCase와 FavoriteManager를 활용하도록 개선

### 🚀 주요 변경 사항
- ChartUseCase는 데이터 요청만 처리하고 변환은 ViewModel에서 수행
- CandleServiceType을 활용하여 거래소별 캔들 데이터를 유연하게 가져올 수 있도록 수정
- FavoriteManager를 추가해서 Core Data 접근을 전담
- actor을 사용하여 동시성 문제 방지

### 📷 스크린샷
https://github.com/user-attachments/assets/f34de609-7422-4dd1-894d-a53e2dcce7d7



### 💡 추가 계획
  - 웹소켓 사용해서 실시간 차트데이터 및 코인 시세 기능 구현