### PR TITLE
[#113]: chartrefactor

### DIFF
--- a/ToTheMoon/ToTheMoon/Model/Shared/SymbolData.swift
+++ b/ToTheMoon/ToTheMoon/Model/Shared/SymbolData.swift
@@ -20,6 +20,13 @@ struct SymbolData: Decodable {
     let name: String
     let image: SymbolImage?
     let description: Description
+    let market_data: MarketData?
+}
+
+struct MarketData: Decodable {
+    let market_cap: [String: Double]?
+    let circulating_supply: Double?
+    let max_supply: Double?
 }
 
 struct SymbolImage: Decodable {

--- a/ToTheMoon/ToTheMoon/Model/Shared/SymbolData.swift
+++ b/ToTheMoon/ToTheMoon/Model/Shared/SymbolData.swift
@@ -11,6 +11,7 @@ import UIKit
 struct SymbolID: Decodable {
     let id: String
     let symbol: String
+    let name: String
 }
 
 struct SymbolData: Decodable {
@@ -26,5 +27,5 @@ struct SymbolImage: Decodable {
 }
 
 struct Description: Decodable {
-    let ko: String
+    let ko: String?
 }

--- a/ToTheMoon/ToTheMoon/Repository/ImageRepository.swift
+++ b/ToTheMoon/ToTheMoon/Repository/ImageRepository.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class ImageRepository {
     // 코인 심볼 -> 번들 이미지 매핑
-    private static let defaultSymbolImages: [String: String] = [
+    static let defaultSymbolImages: [String: String] = [
         "AAVE": "aave",
         "ACH": "alchemy-pay",
         "ACS": "access-protocol",

--- a/ToTheMoon/ToTheMoon/Services/Common/SymbolService.swift
+++ b/ToTheMoon/ToTheMoon/Services/Common/SymbolService.swift
@@ -13,14 +13,6 @@ final class SymbolService {
     private let networkManager = NetworkManager.shared
     private let baseURL = APIEndpoint.coinGecko.baseURL
     
-    /// 기존에 있던 fetchCoinData
-    /// struct SymbolData: Decodable {
-    ///    let id: String
-    ///    let symbol: String
-    ///    let name: String
-    ///    let image: SymbolImage?
-    ///    let description: Description
-    /// }
     func fetchCoinDataAll(coinSymbol: String) -> Single<SymbolData> {
            let endpoint = "\(baseURL)/\(coinSymbol)"
            guard let url = URL(string: endpoint) else {
@@ -63,7 +55,7 @@ final class SymbolService {
     }
     
     // 코인 ID를 사용하여 데이터 가져오기
-    private func fetchCoinDataByID(_ coinID: String) -> Single<SymbolData> {
+    func fetchCoinDataByID(_ coinID: String) -> Single<SymbolData> {
         let endpoint = "\(baseURL)/\(coinID)"
         guard let url = URL(string: endpoint) else {
             return Single.error(NetworkError.invalidUrl)

--- a/ToTheMoon/ToTheMoon/UseCase/ChartUseCase.swift
+++ b/ToTheMoon/ToTheMoon/UseCase/ChartUseCase.swift
@@ -18,6 +18,9 @@ final class ChartUseCase {
     private let exchange: Exchange?
     private let services: [Exchange: CandleServiceType]
     private let webSocketServices: [Exchange: WebSocketServiceProtocol]
+    private let symbolService = SymbolService()
+    private var coinDescriptionCache: [String: String] = [:]
+    
     
     init(exchange: Exchange?) {
         self.exchange = exchange
@@ -95,6 +98,43 @@ final class ChartUseCase {
             }
             .observe(on: MainScheduler.instance)
     }
+    
+    func fetchCoinDescriptionByImageRepository(for symbol: String) -> Observable<String> {
+        if let cachedDescription = coinDescriptionCache[symbol.uppercased()] {
+            print("✅ 캐시에서 설명 데이터 반환: \(symbol)")
+            return Observable.just(cachedDescription)
+        }
+
+        if let coinID = ImageRepository.defaultSymbolImages[symbol.uppercased()] {
+            return symbolService.fetchCoinDataByID(coinID)
+                .asObservable()
+                .do(onNext: { [weak self] data in
+                    let description = data.description.ko?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? data.description.ko! : "설명 데이터가 제공되지 않습니다."
+                    self?.coinDescriptionCache[symbol.uppercased()] = description
+                })
+                .map { $0.description.ko ?? "설명 데이터가 제공되지 않습니다." }
+                .catchAndReturn("설명 데이터를 가져올 수 없습니다.")
+        } else {
+            return Observable.just("❌ 설명 데이터를 찾을 수 없습니다.")
+        }
+    }
+    
+    // ✅ 코인 설명 데이터 가져오기
+    func fetchCoinDescription(for symbol: String) -> Observable<String> {
+        if let cachedDescription = coinDescriptionCache[symbol.uppercased()] {
+            return Observable.just(cachedDescription)
+        }
+
+        return symbolService.fetchCoinData(coinSymbol: symbol)
+            .asObservable()
+            .map { [weak self] data in
+                let description = data.description.ko?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? data.description.ko! : "설명 데이터가 제공되지 않습니다."
+                self?.coinDescriptionCache[symbol.uppercased()] = description
+                return description
+            }
+            .catchAndReturn("설명 데이터를 가져올 수 없습니다.")
+    }
+    
 }
 
 // MARK: - CandleServiceType Conformance

--- a/ToTheMoon/ToTheMoon/UseCase/ChartUseCase.swift
+++ b/ToTheMoon/ToTheMoon/UseCase/ChartUseCase.swift
@@ -42,17 +42,29 @@ final class ChartUseCase {
         guard let exchange = exchange, let service = services[exchange] else {
             return Observable.just(([], [], "0", "0", IndexAxisValueFormatter(values: [])))
         }
-        
+
         return service.fetchCandles(symbol: coin.symbol, interval: interval, count: 50)
             .asObservable()
             .map { candles in
                 let timestamps = candles.map { TimeInterval($0.timestamp / 1000) }
                 let formatter = DateFormatter()
-                formatter.dateFormat = interval == .minute ? "HH:mm" : "M월 d일"
-                let dates = timestamps.map { formatter.string(from: Date(timeIntervalSince1970: $0)) }.reversed()
                 
+                // ✅ 단위별 날짜 포맷 통일
+                switch interval {
+                case .minute:
+                    formatter.dateFormat = "HH:mm"
+                case .day:
+                    formatter.dateFormat = "yyyy-MM-dd"
+                case .week:
+                    formatter.dateFormat = "yyyy-MM-dd"
+                case .month:
+                    formatter.dateFormat = "yyyy년 MM월"
+                @unknown default:
+                    formatter.dateFormat = "yyyy-MM-dd"
+                }
+
+                let dates = timestamps.map { formatter.string(from: Date(timeIntervalSince1970: $0)) }.reversed()
                 let entries = candles.enumerated().map { index, candle in
-                    
                     CandleChartDataEntry(
                         x: Double(index),
                         shadowH: candle.high,
@@ -61,10 +73,10 @@ final class ChartUseCase {
                         close: candle.close
                     )
                 }
-                
+
                 let highest = candles.max(by: { $0.high < $1.high })?.high ?? 0
                 let lowest = candles.min(by: { $0.low < $1.low })?.low ?? 0
-                
+
                 return (Array(dates), entries, "\(highest)", "\(lowest)", IndexAxisValueFormatter(values: Array(dates)))
             }
     }

--- a/ToTheMoon/ToTheMoon/UseCase/ChartUseCase.swift
+++ b/ToTheMoon/ToTheMoon/UseCase/ChartUseCase.swift
@@ -20,6 +20,7 @@ final class ChartUseCase {
     private let webSocketServices: [Exchange: WebSocketServiceProtocol]
     private let symbolService = SymbolService()
     private var coinDescriptionCache: [String: String] = [:]
+    private var coinDataCache: [String: SymbolData] = [:]
     
     
     init(exchange: Exchange?) {
@@ -99,23 +100,22 @@ final class ChartUseCase {
             .observe(on: MainScheduler.instance)
     }
     
-    func fetchCoinDescriptionByImageRepository(for symbol: String) -> Observable<String> {
-        if let cachedDescription = coinDescriptionCache[symbol.uppercased()] {
-            print("✅ 캐시에서 설명 데이터 반환: \(symbol)")
-            return Observable.just(cachedDescription)
+    // ✅ 이미지 레포지토리를 통한 데이터 가져오기 (설명 + 시가총액 등)
+    func fetchCoinFullDataByImageRepository(for symbol: String) -> Observable<SymbolData> {
+        if let cachedData = coinDataCache[symbol.uppercased()] {
+            print("✅ 캐시에서 코인 데이터 반환: \(symbol)")
+            return Observable.just(cachedData)
         }
 
         if let coinID = ImageRepository.defaultSymbolImages[symbol.uppercased()] {
             return symbolService.fetchCoinDataByID(coinID)
                 .asObservable()
                 .do(onNext: { [weak self] data in
-                    let description = data.description.ko?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? data.description.ko! : "설명 데이터가 제공되지 않습니다."
-                    self?.coinDescriptionCache[symbol.uppercased()] = description
+                    self?.coinDataCache[symbol.uppercased()] = data
                 })
-                .map { $0.description.ko ?? "설명 데이터가 제공되지 않습니다." }
-                .catchAndReturn("설명 데이터를 가져올 수 없습니다.")
+                .catchAndReturn(SymbolData(id: "", symbol: "", name: "", image: nil, description: Description(ko: "설명 데이터를 가져올 수 없습니다."), market_data: nil))
         } else {
-            return Observable.just("❌ 설명 데이터를 찾을 수 없습니다.")
+            return Observable.just(SymbolData(id: "", symbol: "", name: "", image: nil, description: Description(ko: "❌ 데이터 매핑 실패"), market_data: nil))
         }
     }
     
@@ -135,6 +135,18 @@ final class ChartUseCase {
             .catchAndReturn("설명 데이터를 가져올 수 없습니다.")
     }
     
+}
+
+extension ChartUseCase {
+    func fetchCoinDescriptionByImageRepository(for symbol: String) -> Observable<String> {
+        guard let coinID = ImageRepository.defaultSymbolImages[symbol.uppercased()] else {
+            return Observable.just("❌ 설명 데이터를 찾을 수 없습니다.")
+        }
+        return symbolService.fetchCoinDataByID(coinID)
+            .asObservable()
+            .map { $0.description.ko ?? "설명 데이터가 제공되지 않습니다." }
+            .catchAndReturn("설명 데이터를 가져올 수 없습니다.")
+    }
 }
 
 // MARK: - CandleServiceType Conformance

--- a/ToTheMoon/ToTheMoon/View/Chart/ChartView.swift
+++ b/ToTheMoon/ToTheMoon/View/Chart/ChartView.swift
@@ -87,10 +87,6 @@ class ChartView: UIView {
         stackView.spacing = 5
         return stackView
     }()
-
-    let totalSupplyLabel = ChartView.createInfoLabel(title: "총 발행 수량", value: "준비중")
-    let marketCapLabel = ChartView.createInfoLabel(title: "시가 총액", value: "준비중")
-    let circulatingSupplyLabel = ChartView.createInfoLabel(title: "현재 유통량", value: "준비중")
     
     // 디지털 자산 소개 컨테이너
     private let digitalAssetContainerView: UIView = {
@@ -123,11 +119,6 @@ class ChartView: UIView {
     """
         return textView
     }()
-
-    let minuteButton = ChartView.createTimeButton(title: "분")
-    let dayButton = ChartView.createTimeButton(title: "일")
-    let weekButton = ChartView.createTimeButton(title: "주")
-    let monthButton = ChartView.createTimeButton(title: "월")
 
     // 차트 뷰
     private let candleStickChartView: CandleStickChartView = {
@@ -188,9 +179,33 @@ class ChartView: UIView {
     let lowestPriceValueLabel = ChartView.createPriceValueLabel(textColor: .numbersRed)
     let changeRateLabel = ChartView.createPriceLabel(text: "변동률")
     let changeRateValueLabel = ChartView.createPriceValueLabel(textColor: .text)
+    
+    let minuteButton = ChartView.createTimeButton(title: "분")
+    let dayButton = ChartView.createTimeButton(title: "일")
+    let weekButton = ChartView.createTimeButton(title: "주")
+    let monthButton = ChartView.createTimeButton(title: "월")
+    
+    private let totalSupplySection: (containerView: UIView, valueLabel: UILabel)
+    private let marketCapSection: (containerView: UIView, valueLabel: UILabel)
+    private let circulatingSupplySection: (containerView: UIView, valueLabel: UILabel)
+
+    let totalSupplyValueLabel: UILabel
+    let marketCapValueLabel: UILabel
+    let circulatingSupplyValueLabel: UILabel
 
     // MARK: - 초기화
     override init(frame: CGRect) {
+        
+        totalSupplySection = ChartView.createInfoLabel(title: "총 발행 수량", value: "준비중")
+        totalSupplyValueLabel = totalSupplySection.valueLabel
+
+        marketCapSection = ChartView.createInfoLabel(title: "시가 총액", value: "준비중")
+        marketCapValueLabel = marketCapSection.valueLabel
+
+        circulatingSupplySection = ChartView.createInfoLabel(title: "현재 유통량", value: "준비중")
+        circulatingSupplyValueLabel = circulatingSupplySection.valueLabel
+        
+        
         super.init(frame: frame)
         setupUI()
     }
@@ -240,9 +255,9 @@ class ChartView: UIView {
 
         // 공급 정보
         coinInfoContainerView.addSubview(supplyInfoStackView)
-        supplyInfoStackView.addArrangedSubview(totalSupplyLabel)
-        supplyInfoStackView.addArrangedSubview(marketCapLabel)
-        supplyInfoStackView.addArrangedSubview(circulatingSupplyLabel)
+        supplyInfoStackView.addArrangedSubview(totalSupplySection.containerView)
+        supplyInfoStackView.addArrangedSubview(marketCapSection.containerView)
+        supplyInfoStackView.addArrangedSubview(circulatingSupplySection.containerView)
 
         // 디지털 자산 소개
         digitalAssetContainerView.addSubview(digitalAssetIntroLabel)
@@ -354,7 +369,7 @@ class ChartView: UIView {
         return stackView
     }
     
-    private static func createInfoLabel(title: String, value: String) -> UIView {
+    private static func createInfoLabel(title: String, value: String) -> (containerView: UIView, valueLabel: UILabel) {
         let containerView = UIView()
 
         let titleLabel = UILabel()
@@ -372,12 +387,11 @@ class ChartView: UIView {
         stackView.distribution = .equalSpacing
 
         containerView.addSubview(stackView)
-
         stackView.snp.makeConstraints { make in
             make.edges.equalToSuperview().inset(10)
         }
 
-        return containerView
+        return (containerView, valueLabel)  // ✅ 함께 반환
     }
     
     private static func createPriceLabel(text: String) -> UILabel {

--- a/ToTheMoon/ToTheMoon/View/Chart/ChartViewController.swift
+++ b/ToTheMoon/ToTheMoon/View/Chart/ChartViewController.swift
@@ -1,11 +1,3 @@
-//
-//  CharViewController.swift
-//  ToTheMoon
-//
-//  Created by 황석범 on 1/21/25.
-//
-
-
 import UIKit
 import RxSwift
 import RxCocoa
@@ -13,7 +5,7 @@ import DGCharts
 import SnapKit
 
 class ChartViewController: UIViewController, UIGestureRecognizerDelegate {
-    
+
     private let chartView = ChartView()
     private let viewModel: ChartViewModel
     private let manageFavoritesUseCase: ManageFavoritesUseCase
@@ -22,41 +14,40 @@ class ChartViewController: UIViewController, UIGestureRecognizerDelegate {
     
     // 현재 선택된 시간 간격 (초기값 .day)
     private var selectedTimeFrame: CandleInterval = .day
-    
+
     init(viewModel: ChartViewModel, manageFavoritesUseCase: ManageFavoritesUseCase = ManageFavoritesUseCase()) {
-        print("DEBUG: Initializing ChartViewController with viewModel: \(viewModel)")
         self.viewModel = viewModel
         self.manageFavoritesUseCase = manageFavoritesUseCase
         super.init(nibName: nil, bundle: nil)
     }
-    
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-        
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setupViews()
         setupBindings()
-        bindViewModel()
-        bindSymbolImage()
         setupNavigationBar()
         navigationController?.navigationBar.isHidden = false
-        
-        // 기본 시간 간격 설정 (.day)
         updateSelectedTimeFrame(.day)
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
-        // 웹소켓 연결 실행 (이전 화면이 닫힌 후 실행)
         guard let firstCoin = viewModel.input.selectedCoins.value.first else { return }
         viewModel.subscribeToRealTimeUpdates(for: firstCoin)
     }
-    
-    // MARK: - Navigation Bar 설정
+
+    // MARK: - View 및 Navigation 설정
+
+    private func setupViews() {
+        view.backgroundColor = .clear
+        view.addSubview(chartView)
+        chartView.snp.makeConstraints { $0.edges.equalToSuperview() }
+    }
+
     private func setupNavigationBar() {
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationController?.navigationBar.tintColor = .text
@@ -68,154 +59,96 @@ class ChartViewController: UIViewController, UIGestureRecognizerDelegate {
             action: #selector(backButtonTapped)
         )
         navigationItem.leftBarButtonItem = backButton
-        
-        // ✅ 스와이프 제스처 활성화 (뒤로 가기 허용)
         navigationController?.interactivePopGestureRecognizer?.delegate = self
         navigationController?.interactivePopGestureRecognizer?.isEnabled = true
     }
-    
+
     @objc private func backButtonTapped() {
         navigationController?.popViewController(animated: true)
     }
-    
+
     private func updateNavigationBarTitle(with coin: MarketPrice) {
         title = "\(coin.symbol.uppercased()) / \(coin.exchange)"
     }
-    
-    // MARK: - View 설정
-    private func setupViews() {
-        view.backgroundColor = .clear
-        view.addSubview(chartView)
-        chartView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
-        }
+
+    // MARK: - Binding 설정
+
+    private func setupBindings() {
+        bindSymbolImage()
+        bindFavoriteButton()
+        bindSelectedCoin()
+        bindChartData()
+        bindCoinDescription()
+        bindTimeFrameButtons()
+        bindGoogleSearch()
     }
-    
+
     private func bindSymbolImage() {
         viewModel.input.selectedCoins
             .asObservable()
-            .map { $0.first?.symbol }      // 첫 번째 코인의 심볼만 가져옴
-            .distinctUntilChanged()          // 심볼이 바뀔 때만 업데이트
+            .map { $0.first?.symbol }
+            .distinctUntilChanged()
             .subscribe(onNext: { [weak self] symbol in
-                guard let self = self, let symbol = symbol else { return }
-                // ImageRepository에서 해당 심볼에 맞는 이미지를 가져오고,
-                // 없으면 "default_coin" 이미지를 사용합니다.
-                let image = ImageRepository.getImage(for: symbol) ?? UIImage(named: "default_coin")
-                self.chartView.coinSymbolImageView.image = image
-            })
-            .disposed(by: disposeBag)
-    }
-    
-    // MARK: - Binding 설정 (입력, 즐겨찾기 등)
-    private func setupBindings() {
-        chartView.favoriteButton.rx.tap
-            .subscribe(onNext: { [weak self] in
-                guard let self = self,
-                      let firstCoin = self.viewModel.input.selectedCoins.value.first else { return }
-                self.viewModel.toggleFavorite(for: firstCoin)
-            })
-            .disposed(by: disposeBag)
-        
-        viewModel.input.selectedCoins
-            .map { $0.first }
-            .compactMap { $0 }
-            .flatMap { [weak self] coin in
-                self?.viewModel.isFavorite(coin) ?? Observable.just(false)
-            }
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] isFavorite in
-                self?.updateFavoriteButtonUI(isFavorite: isFavorite)
-            })
-            .disposed(by: disposeBag)
-        
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(updateFavoriteButtonState),
-            name: NSNotification.Name("FavoriteListUpdated"),
-            object: nil
-        )
-    }
-    
-    private func toggleFavorite(for coin: MarketPrice) {
-        manageFavoritesUseCase.toggleFavorite(coin)
-            .subscribe(onError: { error in
-                print("❌ 즐겨찾기 토글 실패: \(error)")
-            }, onCompleted: {
-                print("✅ 즐겨찾기 토글 완료: \(coin.symbol)")
-                NotificationCenter.default.post(name: NSNotification.Name("FavoriteListUpdated"), object: nil)
+                let image = ImageRepository.getImage(for: symbol ?? "") ?? UIImage(named: "default_coin")
+                self?.chartView.coinSymbolImageView.image = image
             })
             .disposed(by: disposeBag)
     }
 
-    @objc private func updateFavoriteButtonState() {
-        guard let firstCoin = viewModel.input.selectedCoins.value.first else { return }
-        manageFavoritesUseCase.isCoinSaved(firstCoin.symbol, exchange: firstCoin.exchange)
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] isFavorite in
-                self?.updateFavoriteButtonUI(isFavorite: isFavorite)
+    private func bindFavoriteButton() {
+        chartView.favoriteButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                guard let self = self, let firstCoin = self.viewModel.input.selectedCoins.value.first else { return }
+                self.viewModel.toggleFavorite(for: firstCoin)
             })
             .disposed(by: disposeBag)
     }
-    
-    private func updateFavoriteButtonUI(isFavorite: Bool) {
-        let imageName = isFavorite ? "star.fill" : "star"
-        chartView.favoriteButton.setImage(UIImage(systemName: imageName), for: .normal)
-        chartView.favoriteButton.tintColor = isFavorite ? .yellow : .gray
-        
+
+    private func bindSelectedCoin() {
         viewModel.input.selectedCoins
             .map { $0.first }
+            .distinctUntilChanged { $0?.symbol == $1?.symbol } // 🔥 심볼이 바뀔 때만 업데이트
             .compactMap { $0 }
-            .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] firstCoin in
                 self?.updateUI(with: firstCoin)
                 self?.updateNavigationBarTitle(with: firstCoin)
             })
             .disposed(by: disposeBag)
-        
+    }
+
+    private func bindChartData() {
         viewModel.output.chartData
             .drive(onNext: { [weak self] chartData in
                 self?.chartView.configureChart(dates: chartData.dates, dataEntries: chartData.entries)
             })
             .disposed(by: disposeBag)
-        
+
         viewModel.output.highestPrice
-            .drive(onNext: { [weak self] highest in
-                self?.chartView.highestPriceValueLabel.text = highest
-            })
+            .drive(chartView.highestPriceValueLabel.rx.text)
             .disposed(by: disposeBag)
-        
+
         viewModel.output.lowestPrice
-            .drive(onNext: { [weak self] lowest in
-                self?.chartView.lowestPriceValueLabel.text = lowest
-            })
+            .drive(chartView.lowestPriceValueLabel.rx.text)
             .disposed(by: disposeBag)
-        
-        viewModel.output.image
-            .drive(onNext: { [weak self] (symbol, image) in
-                guard let self = self,
-                      let firstCoin = self.viewModel.input.selectedCoins.value.first,
-                      firstCoin.symbol == symbol else { return }
-                self.chartView.coinSymbolImageView.image = image
-            })
-            .disposed(by: disposeBag)
-        
-        setupTimeFrameBindings()
-        chartView.googleSearchButton.rx.tap
-            .subscribe(onNext: { [weak self] in
-                self?.searchCoinOnGoogle()
+    }
+
+    private func bindCoinDescription() {
+        viewModel.output.coinInfo
+            .drive(onNext: { [weak self] info in
+                print("✅ [DEBUG] 전달된 설명 데이터: \(info)")
+                self?.updateCoinDescription(info)
             })
             .disposed(by: disposeBag)
     }
-    
-    // MARK: - 시간 간격 버튼 바인딩
-    private func setupTimeFrameBindings() {
+
+    private func bindTimeFrameButtons() {
         let timeButtons: [(UIButton, CandleInterval)] = [
             (chartView.minuteButton, .minute),
             (chartView.dayButton, .day),
             (chartView.weekButton, .week),
             (chartView.monthButton, .month)
         ]
-        
+
         for (button, interval) in timeButtons {
             button.rx.tap
                 .subscribe(onNext: { [weak self] in
@@ -224,91 +157,68 @@ class ChartViewController: UIViewController, UIGestureRecognizerDelegate {
                 .disposed(by: disposeBag)
         }
     }
-    
+
+    private func bindGoogleSearch() {
+        chartView.googleSearchButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                self?.searchCoinOnGoogle()
+            })
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - 업데이트 메서드
+
     private func updateSelectedTimeFrame(_ newInterval: CandleInterval) {
         selectedTimeFrame = newInterval
         viewModel.input.candleInterval.accept(newInterval)
-        
+
         let allButtons = [chartView.minuteButton, chartView.dayButton, chartView.weekButton, chartView.monthButton]
-        for button in allButtons {
-            button.backgroundColor = .container
-            button.setTitleColor(.text, for: .normal)
+        allButtons.forEach {
+            $0.backgroundColor = .container
+            $0.setTitleColor(.text, for: .normal)
         }
-        
+
         switch newInterval {
-        case .minute:
-            chartView.minuteButton.backgroundColor = .blue.withAlphaComponent(0.3)
-        case .day:
-            chartView.dayButton.backgroundColor = .blue.withAlphaComponent(0.3)
-        case .week:
-            chartView.weekButton.backgroundColor = .blue.withAlphaComponent(0.3)
-        case .month:
-            chartView.monthButton.backgroundColor = .blue.withAlphaComponent(0.3)
-        default:
-            break
+        case .minute: chartView.minuteButton.backgroundColor = .blue.withAlphaComponent(0.3)
+        case .day: chartView.dayButton.backgroundColor = .blue.withAlphaComponent(0.3)
+        case .week: chartView.weekButton.backgroundColor = .blue.withAlphaComponent(0.3)
+        case .month: chartView.monthButton.backgroundColor = .blue.withAlphaComponent(0.3)
+        default: break
         }
     }
-    
+
     private func searchCoinOnGoogle() {
         guard let firstCoin = viewModel.input.selectedCoins.value.first else { return }
-        let coinName = firstCoin.symbol.uppercased()
-        let searchQuery = "https://www.google.com/search?q=\(coinName)+코인"
+        let searchQuery = "https://www.google.com/search?q=\(firstCoin.symbol.uppercased())+코인"
         if let url = URL(string: searchQuery) {
             UIApplication.shared.open(url)
         }
     }
-    
-    private func bindViewModel() {
-        viewModel.output.coinInfo
-            .drive(onNext: { [weak self] info in
-                self?.updateCoinDescription(info)
-            })
-            .disposed(by: disposeBag)
-    }
-    
+
     private func updateUI(with firstCoin: MarketPrice) {
         uiDisposeBag = DisposeBag()
-        
-        let coinSymbol = firstCoin.symbol
-        let coinExchange = firstCoin.exchange
-        chartView.coinNameLabel.text = "\(coinSymbol.uppercased()) (\(coinExchange))"
-        
+        chartView.coinNameLabel.text = "\(firstCoin.symbol.uppercased()) (\(firstCoin.exchange))"
+
         viewModel.output.currentPrices
             .map { $0[firstCoin.symbol] ?? "0" }
             .distinctUntilChanged()
             .drive(chartView.currentPriceLabel.rx.text)
             .disposed(by: uiDisposeBag)
-        
+
         viewModel.output.priceChangeRates
-            .map { rates in
-                let formattedRates = rates.mapValues { value in
-                    if let doubleValue = Double(value.replacingOccurrences(of: "%", with: "")) {
-                        return String(format: "%.2f%%", doubleValue)
-                    }
-                    return value
-                }
-                return formattedRates
-            }
             .map { $0[firstCoin.symbol] ?? "0%" }
             .distinctUntilChanged()
             .drive(chartView.changeRateValueLabel.rx.text)
             .disposed(by: uiDisposeBag)
-        
-        viewModel.output.coinInfo
-            .map { $0[firstCoin.symbol.uppercased()] ?? "설명 데이터를 가져올 수 없습니다." }
-            .distinctUntilChanged()
-            .drive(onNext: { [weak self] description in
-                self?.chartView.digitalAssetDescriptionTextView.text = description
-            })
-            .disposed(by: uiDisposeBag)
     }
-    
+
     private func updateCoinDescription(_ info: [String: String]) {
         DispatchQueue.main.async {
-            if let firstKey = info.keys.first, let description = info[firstKey] {
+            if let description = info.values.first {
+                print("✅ [DEBUG] 업데이트할 설명 데이터: \(description)")
                 self.chartView.digitalAssetDescriptionTextView.text = description
             } else {
-                self.chartView.digitalAssetDescriptionTextView.text = "설명 데이터 준비중"
+                self.chartView.digitalAssetDescriptionTextView.text = "설명 데이터를 가져올 수 없습니다."
             }
         }
     }

--- a/ToTheMoon/ToTheMoon/View/Chart/ChartViewController.swift
+++ b/ToTheMoon/ToTheMoon/View/Chart/ChartViewController.swift
@@ -79,8 +79,19 @@ class ChartViewController: UIViewController, UIGestureRecognizerDelegate {
         bindSelectedCoin()
         bindChartData()
         bindCoinDescription()
+        bindCoinDetails()
         bindTimeFrameButtons()
         bindGoogleSearch()
+    }
+    
+    private func bindCoinDetails() {
+        viewModel.output.coinDetails
+            .drive(onNext: { [weak self] totalSupply, circulatingSupply, marketCap in
+                self?.chartView.totalSupplyValueLabel.text = totalSupply
+                self?.chartView.circulatingSupplyValueLabel.text = circulatingSupply
+                self?.chartView.marketCapValueLabel.text = marketCap
+            })
+            .disposed(by: disposeBag)
     }
 
     private func bindSymbolImage() {
@@ -107,11 +118,14 @@ class ChartViewController: UIViewController, UIGestureRecognizerDelegate {
     private func bindSelectedCoin() {
         viewModel.input.selectedCoins
             .map { $0.first }
-            .distinctUntilChanged { $0?.symbol == $1?.symbol } // 🔥 심볼이 바뀔 때만 업데이트
+            .distinctUntilChanged { $0?.symbol == $1?.symbol }
             .compactMap { $0 }
             .subscribe(onNext: { [weak self] firstCoin in
                 self?.updateUI(with: firstCoin)
                 self?.updateNavigationBarTitle(with: firstCoin)
+                self?.viewModel.fetchAndUpdateAllCoinData(for: firstCoin.symbol) // ✅ 추가된 부분
+                    .subscribe()
+                    .disposed(by: self!.disposeBag)
             })
             .disposed(by: disposeBag)
     }

--- a/ToTheMoon/ToTheMoon/ViewModel/ChartViewModel.swift
+++ b/ToTheMoon/ToTheMoon/ViewModel/ChartViewModel.swift
@@ -37,6 +37,7 @@ final class ChartViewModel {
     private let disposeBag = DisposeBag()
     private let chartUseCase: ChartUseCase
     private let manageFavoritesUseCase: ManageFavoritesUseCase
+    private var descriptionDisposeBag = DisposeBag()
     
     // 내부 Relay
     private let chartDataRelay = BehaviorRelay<(dates: [String], entries: [CandleChartDataEntry], highest: String, lowest: String, xAxisFormatter: AxisValueFormatter)>(
@@ -70,15 +71,29 @@ final class ChartViewModel {
         setupBindings()
     }
     
+    // ✅ 선택된 코인에 대해서만 설명 데이터 불러오기
     private func setupBindings() {
-        input.selectedCoins.asObservable()
-            .subscribe(onNext: { [weak self] coins in
-                guard let self = self, let firstCoin = coins.first else { return }
+        input.selectedCoins
+            .map { $0.first }
+            .distinctUntilChanged { $0?.symbol == $1?.symbol }
+            .compactMap { $0 }
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance) // ✅ 500ms 대기
+            .flatMapLatest { [weak self] firstCoin -> Observable<String> in
+                guard let self = self else { return .just("❌ 설명 데이터를 가져올 수 없습니다.") }
                 self.fetchAndUpdateChartData(for: firstCoin)
-                self.subscribeToRealTimeUpdates(for: firstCoin) // ✅ 여기 수정
+                self.subscribeToRealTimeUpdates(for: firstCoin)
+                return self.chartUseCase.fetchCoinDescriptionByImageRepository(for: firstCoin.symbol)
+            }
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] description in
+                guard let symbol = self?.input.selectedCoins.value.first?.symbol else { return }
+                self?.coinInfoRelay.accept([symbol.uppercased(): description])
+                print("✅ [INFO] 설명 데이터 업데이트 완료: \\(symbol)")
+            }, onError: { error in
+                print("❌ [ERROR] 설명 데이터 업데이트 실패: \\(error.localizedDescription)")
             })
             .disposed(by: disposeBag)
-        
+
         input.candleInterval
             .distinctUntilChanged()
             .subscribe(onNext: { [weak self] _ in
@@ -89,7 +104,30 @@ final class ChartViewModel {
             .disposed(by: disposeBag)
     }
     
-    // ✅ **차트 데이터 가져오기 (REST API)**
+    // 코인 설명 데이터 가져오기
+    func fetchAndUpdateCoinDescription(for symbol: String) {
+        descriptionDisposeBag = DisposeBag() // ✅ 기존 요청 취소
+        coinInfoRelay.accept([symbol.uppercased(): "📡 설명 데이터를 불러오는 중입니다..."])
+
+        chartUseCase.fetchCoinDescriptionByImageRepository(for: symbol)
+            .observe(on: MainScheduler.instance)
+            .retryWhen { (errorObservable: Observable<Error>) in
+                errorObservable.enumerated().flatMap { (attempt, error) -> Observable<Int> in
+                    let delay = pow(2.0, Double(attempt)) // 2, 4, 8초 대기
+                    print("⚡ 재요청 대기: \(delay)초 후 재시도")
+                    return Observable<Int>.timer(RxTimeInterval.seconds(Int(delay)), scheduler: MainScheduler.instance)
+                }
+            }
+            .subscribe(onNext: { [weak self] description in
+                self?.coinInfoRelay.accept([symbol.uppercased(): description])
+                print("✅ [INFO] 설명 데이터 업데이트 완료: \(symbol)")
+            }, onError: { error in
+                print("❌ [ERROR] 설명 데이터 업데이트 실패: \(error.localizedDescription)")
+            })
+            .disposed(by: descriptionDisposeBag)
+    }
+    
+    // 차트 데이터 가져오기 (REST API)
     private func fetchAndUpdateChartData(for coin: MarketPrice) {
         chartUseCase.fetchChartData(for: coin, interval: input.candleInterval.value)
             .observe(on: MainScheduler.instance)
@@ -106,7 +144,7 @@ final class ChartViewModel {
             .disposed(by: disposeBag)
     }
     
-    // ✅ **실시간 캔들 업데이트 (WebSocket)**
+    // 실시간 캔들 업데이트 (WebSocket)
     func subscribeToRealTimeUpdates(for coin: MarketPrice) {
         chartUseCase.subscribeToRealTimeCandleData(for: coin)
             .observe(on: MainScheduler.instance)

--- a/ToTheMoon/ToTheMoon/ViewModel/ChartViewModel.swift
+++ b/ToTheMoon/ToTheMoon/ViewModel/ChartViewModel.swift
@@ -5,7 +5,6 @@
 //  Created by 황석범 on 1/21/25.
 //
 
-
 import RxSwift
 import RxCocoa
 import DGCharts
@@ -28,6 +27,7 @@ final class ChartViewModel {
         let highestPrice: Driver<String>
         let lowestPrice: Driver<String>
         let image: Driver<(String, UIImage?)>
+        let coinDetails: Driver<(totalSupply: String, circulatingSupply: String, marketCap: String)>
     }
     
     let input: Input
@@ -49,6 +49,7 @@ final class ChartViewModel {
     private let highestPriceRelay = BehaviorRelay<String>(value: "0")
     private let lowestPriceRelay = BehaviorRelay<String>(value: "0")
     private let imageSubject = PublishSubject<(String, UIImage?)>()
+    private let coinDetailsRelay = BehaviorRelay<(totalSupply: String, circulatingSupply: String, marketCap: String)>(value: ("0", "0", "0"))
     
     init(exchange: Exchange?, selectedCoins: [MarketPrice], manageFavoritesUseCase: ManageFavoritesUseCase = ManageFavoritesUseCase()) {
         let selectedCoinsRelay = BehaviorRelay<[MarketPrice]>(value: selectedCoins)
@@ -65,7 +66,8 @@ final class ChartViewModel {
             coinInfo: coinInfoRelay.asDriver(),
             highestPrice: highestPriceRelay.asDriver(),
             lowestPrice: lowestPriceRelay.asDriver(),
-            image: imageSubject.asDriver(onErrorDriveWith: .empty())
+            image: imageSubject.asDriver(onErrorDriveWith: .empty()),
+            coinDetails: coinDetailsRelay.asDriver()
         )
         
         setupBindings()
@@ -73,35 +75,66 @@ final class ChartViewModel {
     
     // ✅ 선택된 코인에 대해서만 설명 데이터 불러오기
     private func setupBindings() {
-        input.selectedCoins
-            .map { $0.first }
-            .distinctUntilChanged { $0?.symbol == $1?.symbol }
-            .compactMap { $0 }
-            .throttle(.milliseconds(500), scheduler: MainScheduler.instance) // ✅ 500ms 대기
-            .flatMapLatest { [weak self] firstCoin -> Observable<String> in
-                guard let self = self else { return .just("❌ 설명 데이터를 가져올 수 없습니다.") }
+        input.selectedCoins.asObservable()
+            .subscribe(onNext: { [weak self] coins in
+                guard let self = self, let firstCoin = coins.first else { return }
                 self.fetchAndUpdateChartData(for: firstCoin)
                 self.subscribeToRealTimeUpdates(for: firstCoin)
-                return self.chartUseCase.fetchCoinDescriptionByImageRepository(for: firstCoin.symbol)
-            }
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] description in
-                guard let symbol = self?.input.selectedCoins.value.first?.symbol else { return }
-                self?.coinInfoRelay.accept([symbol.uppercased(): description])
-                print("✅ [INFO] 설명 데이터 업데이트 완료: \\(symbol)")
-            }, onError: { error in
-                print("❌ [ERROR] 설명 데이터 업데이트 실패: \\(error.localizedDescription)")
             })
             .disposed(by: disposeBag)
-
+        
         input.candleInterval
             .distinctUntilChanged()
             .subscribe(onNext: { [weak self] _ in
                 guard let self = self, let firstCoin = self.input.selectedCoins.value.first else { return }
-                print("✅ 차트 업데이트 - 새로운 시간 간격 적용")
+                // 차트 데이터만 초기화합니다. (설명 데이터 등은 유지)
+                self.chartDataRelay.accept(([], [], "0", "0", IndexAxisValueFormatter(values: [])))
                 self.fetchAndUpdateChartData(for: firstCoin)
+                self.subscribeToRealTimeUpdates(for: firstCoin)
             })
             .disposed(by: disposeBag)
+    }
+    
+    // ✅ 숫자에 콤마 추가 (100,000,000)
+    private func formatNumber(_ number: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 2
+        return formatter.string(from: NSNumber(value: number)) ?? "\(number)"
+    }
+
+    // ✅ 시가총액 한국식 단위로 변환 (1억, 1조 등)
+    private func formatMarketCap(_ value: Double) -> String {
+        let trillion = 1_000_000_000_000.0
+        let billion = 100_000_000.0
+        let million = 1_000_000.0
+        
+        if value >= trillion {
+            return "\(String(format: "%.2f", value / trillion))조"
+        } else if value >= billion {
+            return "\(String(format: "%.2f", value / billion))억"
+        } else if value >= million {
+            return "\(String(format: "%.2f", value / million))백만"
+        } else {
+            return formatNumber(value)
+        }
+    }
+    
+    func fetchAndUpdateAllCoinData(for symbol: String) -> Observable<Void> {
+        return Observable.zip(
+            chartUseCase.fetchCoinDescriptionByImageRepository(for: symbol),
+            chartUseCase.fetchCoinFullDataByImageRepository(for: symbol)
+        )
+        .observe(on: MainScheduler.instance)
+        .do(onNext: { [weak self] description, data in
+            self?.coinInfoRelay.accept([symbol.uppercased(): description])
+            let totalSupply = self?.formatNumber(data.market_data?.max_supply ?? 0.0) ?? "0"
+            let circulatingSupply = self?.formatNumber(data.market_data?.circulating_supply ?? 0.0) ?? "0"
+            let marketCapValue = data.market_data?.market_cap?["krw"] ?? 0.0
+            let marketCap = self?.formatMarketCap(marketCapValue) ?? "0"
+            self?.coinDetailsRelay.accept((totalSupply, circulatingSupply, marketCap))
+        })
+        .map { _ in }
     }
     
     // 코인 설명 데이터 가져오기
@@ -133,13 +166,24 @@ final class ChartViewModel {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] newData in
                 guard let self = self else { return }
-                
-                self.chartDataRelay.accept(newData)
-                self.highestPriceRelay.accept(newData.highest) // ✅ 최고가 업데이트
-                self.lowestPriceRelay.accept(newData.lowest)   // ✅ 최저가 업데이트
-                
-            }, onError: { error in
-                print("❌ 차트 데이터 가져오기 실패: \(error)")
+
+                // ✅ 기존 데이터와 새로운 데이터 병합
+                let existingDates = self.chartDataRelay.value.dates
+                let existingEntries = self.chartDataRelay.value.entries
+
+                let mergedDates = existingDates + newData.dates.filter { !existingDates.contains($0) }
+                let mergedEntries = existingEntries + newData.entries
+
+                self.chartDataRelay.accept((
+                    mergedDates,
+                    mergedEntries,
+                    newData.highest,
+                    newData.lowest,
+                    IndexAxisValueFormatter(values: mergedDates)
+                ))
+
+                self.highestPriceRelay.accept(newData.highest)
+                self.lowestPriceRelay.accept(newData.lowest)
             })
             .disposed(by: disposeBag)
     }
@@ -150,18 +194,18 @@ final class ChartViewModel {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] livePrice in
                 guard let self = self else { return }
-
+                
                 print("✅ 실시간 업데이트: \(coin.symbol) - \(livePrice.price)")
                 
-                // ✅ 실시간 가격 및 변동률 업데이트
+                // 실시간 가격 및 변동률 업데이트
                 var updatedPrices = self.currentPricesRelay.value
                 updatedPrices[coin.symbol] = "\(livePrice.price)"
                 self.currentPricesRelay.accept(updatedPrices)
-
+                
                 var updatedRates = self.priceChangeRatesRelay.value
                 updatedRates[coin.symbol] = "\(String(format: "%.2f", livePrice.changeRate))%"
                 self.priceChangeRatesRelay.accept(updatedRates)
-
+                
                 let currentTime = Date()
                 let calendar = Calendar.current
                 
@@ -178,72 +222,65 @@ final class ChartViewModel {
                 default:
                     formatter.dateFormat = "yyyy-MM-dd"
                 }
-
-                let newDateLabel = formatter.string(from: currentTime)
-
-                let timestamps = self.chartDataRelay.value.dates.compactMap {
-                    formatter.date(from: $0)
-                }
                 
-                let lastCandleTime = timestamps.last ?? Date.distantPast
+                let newDateLabel = formatter.string(from: currentTime)
                 
                 var updatedEntries = self.chartDataRelay.value.entries
-
+                var updatedDates = self.chartDataRelay.value.dates
+                
                 var shouldCreateNewCandle = false
-                switch self.input.candleInterval.value {
-                case .minute:
-                    shouldCreateNewCandle = calendar.component(.minute, from: currentTime) != calendar.component(.minute, from: lastCandleTime)
-                case .day:
-                    shouldCreateNewCandle = !calendar.isDate(currentTime, inSameDayAs: lastCandleTime)
-                case .week:
-                    shouldCreateNewCandle = calendar.component(.weekOfYear, from: currentTime) != calendar.component(.weekOfYear, from: lastCandleTime)
-                case .month:
-                    shouldCreateNewCandle = calendar.component(.month, from: currentTime) != calendar.component(.month, from: lastCandleTime)
-                @unknown default:
-                    shouldCreateNewCandle = false
+                if let lastDateString = updatedDates.last,
+                   let lastCandleDate = formatter.date(from: lastDateString) {
+                    switch self.input.candleInterval.value {
+                    case .minute:
+                        shouldCreateNewCandle = calendar.component(.minute, from: currentTime) != calendar.component(.minute, from: lastCandleDate)
+                    case .day:
+                        shouldCreateNewCandle = !calendar.isDate(currentTime, inSameDayAs: lastCandleDate)
+                    case .week:
+                        shouldCreateNewCandle = calendar.component(.weekOfYear, from: currentTime) != calendar.component(.weekOfYear, from: lastCandleDate)
+                    case .month:
+                        shouldCreateNewCandle = calendar.component(.month, from: currentTime) != calendar.component(.month, from: lastCandleDate)
+                    @unknown default:
+                        shouldCreateNewCandle = false
+                    }
+                } else {
+                    shouldCreateNewCandle = true
                 }
-
+                
                 if shouldCreateNewCandle {
                     print("✅ 새로운 캔들 생성됨: \(newDateLabel)")
                     let newCandle = CandleChartDataEntry(
                         x: Double(updatedEntries.count),
-                        shadowH: Double(livePrice.price),
-                        shadowL: Double(livePrice.price),
-                        open: Double(livePrice.price),
-                        close: Double(livePrice.price)
+                        shadowH: livePrice.price,
+                        shadowL: livePrice.price,
+                        open: livePrice.price,
+                        close: livePrice.price
                     )
                     updatedEntries.append(newCandle)
-
-                    self.chartDataRelay.accept((
-                        self.chartDataRelay.value.dates + [newDateLabel],
-                        updatedEntries,
-                        self.highestPriceRelay.value,
-                        self.lowestPriceRelay.value,
-                        IndexAxisValueFormatter(values: self.chartDataRelay.value.dates + [newDateLabel])
-                    ))
-
+                    updatedDates.append(newDateLabel)
                 } else {
-                    // ✅ 기존 캔들 업데이트 (형식 일치 유지)
-                    if var lastEntry = updatedEntries.last {
-                        lastEntry = CandleChartDataEntry(
+                    // 기존 캔들 업데이트 (한 번 생성된 캔들은 계속 업데이트)
+                    if let lastEntry = updatedEntries.last {
+                        let updatedLastEntry = CandleChartDataEntry(
                             x: lastEntry.x,
                             shadowH: max(lastEntry.high, livePrice.price),
                             shadowL: min(lastEntry.low, livePrice.price),
                             open: lastEntry.open,
                             close: livePrice.price
                         )
-                        updatedEntries[updatedEntries.count - 1] = lastEntry
+                        updatedEntries[updatedEntries.count - 1] = updatedLastEntry
                     }
-
-                    self.chartDataRelay.accept((
-                        self.chartDataRelay.value.dates,
-                        updatedEntries,
-                        self.highestPriceRelay.value,
-                        self.lowestPriceRelay.value,
-                        IndexAxisValueFormatter(values: self.chartDataRelay.value.dates)
-                    ))
                 }
-
+                
+                // 업데이트된 데이터를 차트에 반영
+                self.chartDataRelay.accept((
+                    updatedDates,
+                    updatedEntries,
+                    self.highestPriceRelay.value,
+                    self.lowestPriceRelay.value,
+                    IndexAxisValueFormatter(values: updatedDates)
+                ))
+                
             }, onError: { error in
                 print("❌ 실시간 데이터 업데이트 실패: \(error)")
             })

--- a/ToTheMoon/ToTheMoon/ViewModel/ChartViewModel.swift
+++ b/ToTheMoon/ToTheMoon/ViewModel/ChartViewModel.swift
@@ -112,40 +112,45 @@ final class ChartViewModel {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] livePrice in
                 guard let self = self else { return }
-                
+
                 print("✅ 실시간 업데이트: \(coin.symbol) - \(livePrice.price)")
                 
+                // ✅ 실시간 가격 및 변동률 업데이트
+                var updatedPrices = self.currentPricesRelay.value
+                updatedPrices[coin.symbol] = "\(livePrice.price)"
+                self.currentPricesRelay.accept(updatedPrices)
+
+                var updatedRates = self.priceChangeRatesRelay.value
+                updatedRates[coin.symbol] = "\(String(format: "%.2f", livePrice.changeRate))%"
+                self.priceChangeRatesRelay.accept(updatedRates)
+
                 let currentTime = Date()
                 let calendar = Calendar.current
                 
-                // 마지막 캔들의 시간 계산 (UTC 기준)
-                let timestamps = self.chartDataRelay.value.dates.compactMap { dateString -> Date? in
-                    let formatter = DateFormatter()
-                    
-                    switch self.input.candleInterval.value {
-                    case .minute:
-                        formatter.dateFormat = "HH:mm"
-                    case .day:
-                        formatter.dateFormat = "yyyy-MM-dd"
-                    case .week:
-                        formatter.dateFormat = "yyyy-'W'ww"
-                    case .month:
-                        formatter.dateFormat = "yyyy-MM"
-                    default:
-                        formatter.dateFormat = "yyyy-MM-dd"
-                    }
-                    
-                    return formatter.date(from: dateString)
+                let formatter = DateFormatter()
+                switch self.input.candleInterval.value {
+                case .minute:
+                    formatter.dateFormat = "HH:mm"
+                case .day:
+                    formatter.dateFormat = "yyyy-MM-dd"
+                case .week:
+                    formatter.dateFormat = "yyyy-MM-dd"
+                case .month:
+                    formatter.dateFormat = "yyyy년 MM월"
+                default:
+                    formatter.dateFormat = "yyyy-MM-dd"
+                }
+
+                let newDateLabel = formatter.string(from: currentTime)
+
+                let timestamps = self.chartDataRelay.value.dates.compactMap {
+                    formatter.date(from: $0)
                 }
                 
                 let lastCandleTime = timestamps.last ?? Date.distantPast
                 
-                self.currentPricesRelay.accept([coin.symbol: "\(livePrice.price)"])
-                self.priceChangeRatesRelay.accept([coin.symbol: "\(livePrice.changeRate)"])
-                
                 var updatedEntries = self.chartDataRelay.value.entries
-                
-                // ✅ 새로운 캔들 생성 기준 (시간 단위별)
+
                 var shouldCreateNewCandle = false
                 switch self.input.candleInterval.value {
                 case .minute:
@@ -159,10 +164,9 @@ final class ChartViewModel {
                 @unknown default:
                     shouldCreateNewCandle = false
                 }
-                
+
                 if shouldCreateNewCandle {
-                    print("✅ 새로운 캔들 생성됨: \(currentTime)")
-                    
+                    print("✅ 새로운 캔들 생성됨: \(newDateLabel)")
                     let newCandle = CandleChartDataEntry(
                         x: Double(updatedEntries.count),
                         shadowH: Double(livePrice.price),
@@ -171,23 +175,7 @@ final class ChartViewModel {
                         close: Double(livePrice.price)
                     )
                     updatedEntries.append(newCandle)
-                    
-                    let formatter = DateFormatter()
-                    switch self.input.candleInterval.value {
-                    case .minute:
-                        formatter.dateFormat = "HH:mm"
-                    case .day:
-                        formatter.dateFormat = "yyyy-MM-dd"
-                    case .week:
-                        formatter.dateFormat = "yyyy-'W'ww"
-                    case .month:
-                        formatter.dateFormat = "yyyy-MM"
-                    default:
-                        formatter.dateFormat = "yyyy-MM-dd"
-                    }
-                    
-                    let newDateLabel = formatter.string(from: currentTime)
-                    
+
                     self.chartDataRelay.accept((
                         self.chartDataRelay.value.dates + [newDateLabel],
                         updatedEntries,
@@ -195,8 +183,9 @@ final class ChartViewModel {
                         self.lowestPriceRelay.value,
                         IndexAxisValueFormatter(values: self.chartDataRelay.value.dates + [newDateLabel])
                     ))
+
                 } else {
-                    // ✅ 기존 마지막 캔들 업데이트 (실시간 반영)
+                    // ✅ 기존 캔들 업데이트 (형식 일치 유지)
                     if var lastEntry = updatedEntries.last {
                         lastEntry = CandleChartDataEntry(
                             x: lastEntry.x,
@@ -207,7 +196,7 @@ final class ChartViewModel {
                         )
                         updatedEntries[updatedEntries.count - 1] = lastEntry
                     }
-                    
+
                     self.chartDataRelay.accept((
                         self.chartDataRelay.value.dates,
                         updatedEntries,
@@ -216,7 +205,7 @@ final class ChartViewModel {
                         IndexAxisValueFormatter(values: self.chartDataRelay.value.dates)
                     ))
                 }
-                
+
             }, onError: { error in
                 print("❌ 실시간 데이터 업데이트 실패: \(error)")
             })


### PR DESCRIPTION
### 📝 작업 내용
  - 차트 데이터 및 실시간 캔들 업데이트 기능 구현
  - 코인 정보(총 발행 수량, 유통 공급량, 시가총액 등)를 이미지 레포지토리와 연동하여 매핑 처리
  - 코인 설명 데이터를 이미지 레포지토리 기반으로 가져와 캐싱 및 제공하는 기능 추가

### 🚀 주요 변경 사항
- REST API를 통해 지정된 코인의 캔들 데이터를 불러오고, 이를 날짜 포맷에 맞게 정렬 및 병합하도록 구현

- 실시간 데이터 업데이트 시, 캔들 생성/업데이트 로직을 개선하여 한 번 생성된 캔들 내에서 계속 업데이트되고, 새로운 시간 간격이 되면 새 캔들이 생성되도록 수정

- fetchCoinFullDataByImageRepository 메서드를 통해 코인의 총 발행 수량, 유통 공급량, 시가총액 등의 정보를 이미지 레포지토리로 매핑하여 가져오고 캐싱 처리

- 가져온 데이터는 차트 하단의 코인 상세 정보 영역에 반영

- fetchCoinDescriptionByImageRepository 메서드를 활용하여, 코인 설명 데이터를 이미지 레포지토리 기반으로 가져오도록 변경

### 📷 스크린샷

https://github.com/user-attachments/assets/fa07d9ec-fab0-4af0-b76e-a555b05934b1

