### PR TITLE
[Update]: 알림 편집 가격 천 단위 콤마, 가격 지정 +/- 버튼 기능 구현

### DIFF
--- a/ToTheMoon/ToTheMoon/View/Alarm/AlarmEditView.swift
+++ b/ToTheMoon/ToTheMoon/View/Alarm/AlarmEditView.swift
@@ -12,7 +12,6 @@ class AlarmEditView: UIView {
     // MARK: - 코인 정보
     let coinNameLabel: UILabel = {
         let label = UILabel()
-        label.text = "노시스 (GNO/KRW)"
         label.font = .systemFont(ofSize: 18, weight: .medium)
         return label
     }()
@@ -34,7 +33,6 @@ class AlarmEditView: UIView {
     
     let currentPriceLabel: UILabel = {
         let label = UILabel()
-        label.text = "272,500 원"
         label.font = .medium.bold()
         label.textColor = .text
         label.textAlignment = .right
@@ -51,7 +49,6 @@ class AlarmEditView: UIView {
     
    let priceChangeLabel: UILabel = {
         let label = UILabel()
-        label.text = "-1.66%"
         label.font = .medium.bold()
         label.textColor = .numbersRed
         label.textAlignment = .right
@@ -68,7 +65,6 @@ class AlarmEditView: UIView {
     
     let dayRangeLabel: UILabel = {
         let label = UILabel()
-        label.text = "290,800 / 266,500"
         label.font = .medium.regular()
         label.textAlignment = .right
         return label
@@ -85,7 +81,6 @@ class AlarmEditView: UIView {
     
     let priceTextField: UITextField = {
         let textField = UITextField()
-        textField.text = "272,500"
         textField.font = .systemFont(ofSize: 19, weight: .bold)
         textField.keyboardType = .numberPad
         textField.borderStyle = .none
@@ -108,7 +103,7 @@ class AlarmEditView: UIView {
         priceTextField.resignFirstResponder()
     }
     
-    private let decreaseButton: UIButton = {
+    let decreaseButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "minus"), for: .normal)
         button.tintColor = .text
@@ -119,7 +114,7 @@ class AlarmEditView: UIView {
         return button
     }()
     
-    private let increaseButton: UIButton = {
+    let increaseButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "plus"), for: .normal)
         button.tintColor = .text

--- a/ToTheMoon/ToTheMoon/View/Alarm/AlarmEditViewController.swift
+++ b/ToTheMoon/ToTheMoon/View/Alarm/AlarmEditViewController.swift
@@ -55,6 +55,55 @@ class AlarmEditViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
+        // 가격 지정 + 버튼
+        alarmEditView.increaseButton.rx.tap
+            .withLatestFrom(viewModel.output.selectedCoinRelay)
+            .withLatestFrom(alarmEditView.priceTextField.rx.text.orEmpty) { (marketPrice, priceText) -> (Double, String) in
+                return (marketPrice.price, priceText)
+            }
+            .subscribe(onNext: { [weak self] marketPrice, priceText in
+                guard let self = self else { return }
+                let priceDigits = priceText.replacingOccurrences(of: ",", with: "")
+                if let currentPrice = Double(priceDigits) {
+                    let onePercent = marketPrice * 0.01
+                    let newPrice = currentPrice + onePercent
+                    
+                    let formatter = NumberFormatter()
+                    formatter.numberStyle = .decimal
+                    formatter.maximumFractionDigits = 0
+                    
+                    if let formattedPrice = formatter.string(from: NSNumber(value: newPrice)) {
+                        self.alarmEditView.priceTextField.text = formattedPrice
+                    }
+                }
+            })
+            .disposed(by: disposeBag)
+
+        // 가격 지정 - 버튼
+        alarmEditView.decreaseButton.rx.tap
+            .withLatestFrom(viewModel.output.selectedCoinRelay)
+            .withLatestFrom(alarmEditView.priceTextField.rx.text.orEmpty) { (marketPrice, priceText) -> (Double, String) in
+                return (marketPrice.price, priceText)
+            }
+            .subscribe(onNext: { [weak self] marketPrice, priceText in
+                guard let self = self else { return }
+                let priceDigits = priceText.replacingOccurrences(of: ",", with: "")
+                if let currentPrice = Double(priceDigits) {
+                    let onePercent = marketPrice * 0.01
+                    let newPrice = currentPrice - onePercent
+                    
+                    let formatter = NumberFormatter()
+                    formatter.numberStyle = .decimal
+                    formatter.maximumFractionDigits = 0
+                    
+                    if let formattedPrice = formatter.string(from: NSNumber(value: newPrice)) {
+                        self.alarmEditView.priceTextField.text = formattedPrice
+                    }
+                }
+            })
+            .disposed(by: disposeBag)
+
+        
         // `percentageSignSegment` 값 변경을 `condition`에 반영
         alarmEditView.percentageSignSegment.rx.selectedSegmentIndex
             .map { $0 == 0 ? "above" : "below" }
@@ -85,9 +134,20 @@ class AlarmEditViewController: UIViewController {
     ///  UI 업데이트 메서드
     private func updateUI(with marketPrice: MarketPrice) {
         alarmEditView.coinNameLabel.text = "\(marketPrice.symbol) (\(marketPrice.exchange))"
-        alarmEditView.currentPriceLabel.text = "\(Int(marketPrice.price)) 원"
         
-        let formattedHighLow = "\(Int(marketPrice.highPrice)) / \(Int(marketPrice.lowPrice))"
+        // 천 단위 구분자를 위한 NumberFormatter 생성
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 0
+        
+        // 현재가에 천 단위 구분자 추가
+        let priceString = formatter.string(from: NSNumber(value: marketPrice.price)) ?? "0"
+        alarmEditView.currentPriceLabel.text = "\(priceString) 원"
+        
+        // 24시 최고/최저에 천 단위 구분자 추가
+        let highPriceString = formatter.string(from: NSNumber(value: marketPrice.highPrice)) ?? "0"
+        let lowPriceString = formatter.string(from: NSNumber(value: marketPrice.lowPrice)) ?? "0"
+        let formattedHighLow = "\(highPriceString) / \(lowPriceString)"
         alarmEditView.dayRangeLabel.text = formattedHighLow
         
         // 가격 변화율 표시
@@ -95,8 +155,9 @@ class AlarmEditViewController: UIViewController {
         alarmEditView.priceChangeLabel.text = changeText
         alarmEditView.priceChangeLabel.textColor = marketPrice.change == "RISE" ? .numbersGreen : .numbersRed
         
-        // 가격 입력 필드 기본값 설정
-        alarmEditView.priceTextField.text = "\(Int(marketPrice.price))"
+        // 가격 지정 필드에 천 단위 구분자 추가
+        let initialPriceString = formatter.string(from: NSNumber(value: Int(marketPrice.price))) ?? "0"
+        alarmEditView.priceTextField.text = initialPriceString
         
         // 코인 이미지 설정
 //        if let image = marketPrice.image {


### PR DESCRIPTION
### 🚀 주요 변경 사항
- 알림 편집 화면 가격들 천 단위로 콤마
- 가격 지정 +/- 버튼 현재가 대비 1% 변동되게 기능 추가

### 📷 스크린샷
<img width="40%" src="https://github.com/user-attachments/assets/d481a0f8-3dba-4366-83c5-341133899787" />

### 💡 추가 계획
  - 알림 목록 기능 수정